### PR TITLE
Feature: BIP-32 implementation

### DIFF
--- a/lib/cryptography_utils.dart
+++ b/lib/cryptography_utils.dart
@@ -2,6 +2,8 @@ library cryptography_utils;
 
 export 'src/bip/bip.dart';
 export 'src/cdsa/cdsa.dart';
+export 'src/config/config.dart';
 export 'src/hash/hmac.dart';
 export 'src/hash/pbkdf2.dart';
+export 'src/slip/slip.dart';
 export 'src/utils/utils.dart';

--- a/lib/src/bip/bip.dart
+++ b/lib/src/bip/bip.dart
@@ -1,1 +1,3 @@
+export 'bip32/bip32.dart';
 export 'bip39/bip39.dart';
+export 'bip_proposal_type.dart';

--- a/lib/src/bip/bip32/bip32.dart
+++ b/lib/src/bip/bip32/bip32.dart
@@ -1,0 +1,10 @@
+export 'derivation_path/legacy_derivation_path/legacy_derivation_path.dart';
+export 'derivation_path/legacy_derivation_path/legacy_derivation_path_element.dart';
+export 'derivators/i_derivator.dart';
+export 'derivators/legacy_derivators/i_legacy_derivator.dart';
+export 'derivators/legacy_derivators/secp256k1_derivator.dart';
+export 'hd_wallet/a_hd_wallet.dart';
+export 'hd_wallet/legacy_hd_wallet.dart';
+export 'keys/bip32_hmac_keys.dart';
+export 'keys/i_bip32_private_key.dart';
+export 'keys/i_bip32_public_key.dart';

--- a/lib/src/bip/bip32/derivation_path/legacy_derivation_path/legacy_derivation_path.dart
+++ b/lib/src/bip/bip32/derivation_path/legacy_derivation_path/legacy_derivation_path.dart
@@ -1,0 +1,48 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:equatable/equatable.dart';
+
+/// [LegacyDerivationPath] represents traditional derivation path used, for example, in Bitcoin, Ethereum, Cosmos and other blockchains.
+/// Derivation path defines a logical hierarchy for deterministic wallets (BIP-44) based on an algorithm described in BIP-32 and purpose scheme described in BIP-43.
+/// [LegacyDerivationPath] contains a list of [LegacyDerivationPathElement] where each element represents a single level of the following path structure:
+/// m / purpose' / coin_type' / account' / change / address_index
+///
+/// https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
+/// https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+/// https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki
+class LegacyDerivationPath extends Equatable {
+  static const String _masterChar = 'm';
+
+  final List<LegacyDerivationPathElement> pathElements;
+
+  LegacyDerivationPath({
+    List<LegacyDerivationPathElement>? pathElements,
+  }) : pathElements = pathElements ?? List<LegacyDerivationPathElement>.empty(growable: true);
+
+  /// Parses a derivation path from a string in the format of
+  /// "m/purpose'/coin_type'/account'/change/address_index".
+  factory LegacyDerivationPath.parse(String derivationPath) {
+    String parsedPath = derivationPath;
+    if (parsedPath.endsWith('/')) {
+      parsedPath = parsedPath.substring(0, parsedPath.length - 1);
+    }
+
+    List<String> separatedPath = parsedPath.split('/').where((String elem) => elem.isNotEmpty).toList();
+    if (separatedPath.isEmpty || separatedPath.first != _masterChar) {
+      throw FormatException('Invalid BIP32 derivation path ($derivationPath)');
+    }
+
+    List<LegacyDerivationPathElement> pathElements = separatedPath.sublist(1).map((String e) {
+      return LegacyDerivationPathElement.parse(e);
+    }).toList();
+    return LegacyDerivationPath(pathElements: pathElements);
+  }
+
+  @override
+  String toString() {
+    List<String> separatedPath = <String>[_masterChar, ...pathElements.map((LegacyDerivationPathElement e) => e.toString())];
+    return separatedPath.join('/');
+  }
+
+  @override
+  List<Object?> get props => <Object?>[pathElements];
+}

--- a/lib/src/bip/bip32/derivation_path/legacy_derivation_path/legacy_derivation_path_element.dart
+++ b/lib/src/bip/bip32/derivation_path/legacy_derivation_path/legacy_derivation_path_element.dart
@@ -1,0 +1,57 @@
+import 'dart:typed_data';
+
+import 'package:equatable/equatable.dart';
+
+/// [LegacyDerivationPathElement] is a class that represents a single element of a BIP32 derivation path.
+class LegacyDerivationPathElement extends Equatable {
+  static const List<String> _hardenedChars = <String>["'"];
+
+  final int index;
+  final String value;
+  final bool _hardenedBool;
+
+  const LegacyDerivationPathElement({
+    required bool hardenedBool,
+    required this.index,
+    required this.value,
+  }) : _hardenedBool = hardenedBool;
+
+  /// Parses a single derivation path element which can be either a hardened or non-hardened index.
+  factory LegacyDerivationPathElement.parse(String pathElement) {
+    String parsedPathElement = pathElement;
+
+    bool hardenedBool = _hardenedChars.where(parsedPathElement.endsWith).isNotEmpty;
+    if (hardenedBool) {
+      parsedPathElement = parsedPathElement.substring(0, pathElement.length - 1);
+    }
+
+    int? index = int.tryParse(parsedPathElement, radix: 10);
+    if (index == null) {
+      throw FormatException('Invalid BIP32 derivation path element ($pathElement)');
+    } else if (hardenedBool) {
+      index = index | (1 << 31);
+    } else {
+      index = index & ~(1 << 31);
+    }
+
+    return LegacyDerivationPathElement(
+      hardenedBool: hardenedBool,
+      index: index,
+      value: pathElement,
+    );
+  }
+
+  /// Returns true if the index is hardened, false otherwise.
+  bool get isHardened => _hardenedBool;
+
+  /// Returns the index as a 32-bit unsigned integer.
+  Uint8List toBytes() {
+    return Uint8List(4)..buffer.asByteData().setInt32(0, index, Endian.big);
+  }
+
+  @override
+  String toString() => value;
+
+  @override
+  List<Object?> get props => <Object>[value, index, _hardenedBool];
+}

--- a/lib/src/bip/bip32/derivators/i_derivator.dart
+++ b/lib/src/bip/bip32/derivators/i_derivator.dart
@@ -1,0 +1,1 @@
+abstract interface class IDerivator {}

--- a/lib/src/bip/bip32/derivators/legacy_derivators/i_legacy_derivator.dart
+++ b/lib/src/bip/bip32/derivators/legacy_derivators/i_legacy_derivator.dart
@@ -1,0 +1,11 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter/material.dart';
+
+@optionalTypeArgs
+abstract interface class ILegacyDerivator<T extends IBip32PrivateKey> implements IDerivator {
+  Future<T> derivePath(Mnemonic mnemonic, LegacyDerivationPath legacyDerivationPath);
+
+  Future<T> deriveMasterKey(Mnemonic mnemonic);
+
+  T deriveChildKey(T privateKey, LegacyDerivationPathElement derivationPathElement);
+}

--- a/lib/src/bip/bip32/derivators/legacy_derivators/secp256k1_derivator.dart
+++ b/lib/src/bip/bip32/derivators/legacy_derivators/secp256k1_derivator.dart
@@ -1,0 +1,117 @@
+// Class was shaped by the influence of several key sources including:
+// "blockchain_utils" - Copyright (c) 2010 Mohsen
+// https://github.com/mrtnetwork/blockchain_utils/.
+//
+// BSD 3-Clause License
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// [Secp256k1Derivator] is a class that implements the derivation of [Secp256k1PrivateKey] objects.
+class Secp256k1Derivator implements ILegacyDerivator<Secp256k1PrivateKey> {
+  static const List<int> _hardenedPrivateKeyPrefix = <int>[0x00];
+
+  /// Derives a [Secp256k1PrivateKey] from a mnemonic pharse and full derivation path
+  @override
+  Future<Secp256k1PrivateKey> derivePath(Mnemonic mnemonic, LegacyDerivationPath legacyDerivationPath) async {
+    Secp256k1PrivateKey masterPrivateKey = await deriveMasterKey(mnemonic);
+    Secp256k1PrivateKey childPrivateKey = masterPrivateKey;
+    for (LegacyDerivationPathElement derivationPathElement in legacyDerivationPath.pathElements) {
+      childPrivateKey = deriveChildKey(childPrivateKey, derivationPathElement);
+    }
+    return childPrivateKey;
+  }
+
+  /// Derives a master [Secp256k1PrivateKey] from a mnemonic phrase
+  @override
+  Future<Secp256k1PrivateKey> deriveMasterKey(Mnemonic mnemonic) async {
+    LegacyMnemonicSeedGenerator seedGenerator = LegacyMnemonicSeedGenerator();
+    Uint8List seed = await seedGenerator.generateSeed(mnemonic);
+    Uint8List hmacHash = HMAC(hash: sha512, key: Bip32HMACKeys.hmacKeySecp256k1Bytes).process(seed);
+
+    Uint8List privateKey = hmacHash.sublist(0, 32);
+    Uint8List chainCode = hmacHash.sublist(32);
+
+    return Secp256k1PrivateKey(
+      ecPrivateKey: ECPrivateKey.fromBytes(privateKey, CurvePoints.generatorSecp256k1),
+      chainCode: chainCode,
+    );
+  }
+
+  /// Derives a child [Secp256k1PrivateKey] from a parent [Secp256k1PrivateKey] and a single element of a derivation path
+  @override
+  Secp256k1PrivateKey deriveChildKey(Secp256k1PrivateKey privateKey, LegacyDerivationPathElement derivationPathElement) {
+    if (derivationPathElement.isHardened) {
+      return _deriveHard(privateKey, derivationPathElement.toBytes());
+    } else {
+      return _deriveSoft(privateKey, derivationPathElement.toBytes());
+    }
+  }
+
+  /// Derives a child [Secp256k1PrivateKey] from a parent [Secp256k1PrivateKey] and a single hardened element of a derivation path
+  Secp256k1PrivateKey _deriveHard(Secp256k1PrivateKey secp256k1privateKey, Uint8List derivationBytes) {
+    Uint8List data = Uint8List.fromList(<int>[..._hardenedPrivateKeyPrefix, ...secp256k1privateKey.bytes, ...derivationBytes]);
+
+    Uint8List hmacHash = HMAC(hash: sha512, key: secp256k1privateKey.chainCode).process(data);
+
+    Uint8List scalarBytes = hmacHash.sublist(0, 32);
+    Uint8List chainCodeBytes = hmacHash.sublist(32);
+
+    BigInt scalar = BigIntUtils.decode(scalarBytes);
+    BigInt privateKeyScalar = BigIntUtils.decode(secp256k1privateKey.bytes);
+    BigInt privateKey = (scalar + privateKeyScalar) % CurvePoints.generatorSecp256k1.n;
+    Uint8List privateKeyBytes = BigIntUtils.changeToBytes(privateKey, length: secp256k1privateKey.length);
+
+    return Secp256k1PrivateKey(
+      ecPrivateKey: ECPrivateKey.fromBytes(privateKeyBytes, CurvePoints.generatorSecp256k1),
+      chainCode: chainCodeBytes,
+    );
+  }
+
+  /// Derives a child [Secp256k1PrivateKey] from a parent [Secp256k1PrivateKey] and a single non-hardened element of a derivation path
+  Secp256k1PrivateKey _deriveSoft(Secp256k1PrivateKey secp256k1privateKey, Uint8List derivationBytes) {
+    Uint8List data = Uint8List.fromList(<int>[...secp256k1privateKey.publicKey.compressed, ...derivationBytes]);
+
+    Uint8List hmacHash = HMAC(hash: sha512, key: secp256k1privateKey.chainCode).process(data);
+
+    Uint8List scalarBytes = hmacHash.sublist(0, 32);
+    Uint8List chainCodeBytes = hmacHash.sublist(32);
+
+    BigInt scalar = BigIntUtils.decode(scalarBytes);
+    BigInt privateKeyScalar = BigIntUtils.decode(secp256k1privateKey.bytes);
+    BigInt privateKey = (scalar + privateKeyScalar) % CurvePoints.generatorSecp256k1.n;
+    Uint8List privateKeyBytes = BigIntUtils.changeToBytes(privateKey, length: secp256k1privateKey.length);
+
+    return Secp256k1PrivateKey(
+      ecPrivateKey: ECPrivateKey.fromBytes(privateKeyBytes, CurvePoints.generatorSecp256k1),
+      chainCode: chainCodeBytes,
+    );
+  }
+}

--- a/lib/src/bip/bip32/hd_wallet/a_hd_wallet.dart
+++ b/lib/src/bip/bip32/hd_wallet/a_hd_wallet.dart
@@ -1,0 +1,20 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:equatable/equatable.dart';
+
+/// [AHDWallet] is an abstract class representing the foundation of a Hierarchical Deterministic (HD) Wallet,
+/// HD Wallets store private keys, public keys and addresses generated from a single master seed.
+/// https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
+abstract class AHDWallet extends Equatable {
+  final AWalletConfig walletConfig;
+  final IBip32PrivateKey privateKey;
+  final IBip32PublicKey publicKey;
+
+  const AHDWallet({
+    required this.walletConfig,
+    required this.privateKey,
+    required this.publicKey,
+  });
+
+  @override
+  List<Object?> get props => <Object>[walletConfig, privateKey, publicKey];
+}

--- a/lib/src/bip/bip32/hd_wallet/legacy_hd_wallet.dart
+++ b/lib/src/bip/bip32/hd_wallet/legacy_hd_wallet.dart
@@ -1,0 +1,36 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// Hierarchical Deterministic Wallet for legacy coins (Bitcoin, Ethereum, Cosmos etc.).
+/// https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
+class LegacyHDWallet extends AHDWallet {
+  final LegacyDerivationPath? derivationPath;
+
+  const LegacyHDWallet({
+    required super.walletConfig,
+    required super.privateKey,
+    required super.publicKey,
+    this.derivationPath,
+  });
+
+  /// Creates a new [LegacyHDWallet] from a mnemonic and a derivation path.
+  static Future<LegacyHDWallet> fromMnemonic({
+    required String derivationPathString,
+    required Mnemonic mnemonic,
+    required LegacyWalletConfig walletConfig,
+  }) async {
+    LegacyDerivationPath derivationPath = LegacyDerivationPath.parse(derivationPathString);
+
+    IBip32PrivateKey bip32PrivateKey = await walletConfig.derivator.derivePath(mnemonic, derivationPath);
+    IBip32PublicKey bip32PublicKey = bip32PrivateKey.publicKey;
+
+    return LegacyHDWallet(
+      walletConfig: walletConfig,
+      privateKey: bip32PrivateKey,
+      publicKey: bip32PublicKey,
+      derivationPath: derivationPath,
+    );
+  }
+
+  @override
+  List<Object?> get props => <Object?>[walletConfig, privateKey, publicKey, derivationPath];
+}

--- a/lib/src/bip/bip32/keys/bip32_hmac_keys.dart
+++ b/lib/src/bip/bip32/keys/bip32_hmac_keys.dart
@@ -1,0 +1,7 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+/// Stores HMAC keys used in BIP-32 derivations.
+class Bip32HMACKeys {
+  static Uint8List get hmacKeySecp256k1Bytes => utf8.encode('Bitcoin seed');
+}

--- a/lib/src/bip/bip32/keys/i_bip32_private_key.dart
+++ b/lib/src/bip/bip32/keys/i_bip32_private_key.dart
@@ -1,0 +1,13 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+abstract interface class IBip32PrivateKey {
+  Uint8List get bytes;
+
+  Uint8List get chainCode;
+
+  int get length;
+
+  IBip32PublicKey get publicKey;
+}

--- a/lib/src/bip/bip32/keys/i_bip32_public_key.dart
+++ b/lib/src/bip/bip32/keys/i_bip32_public_key.dart
@@ -1,0 +1,1 @@
+abstract interface class IBip32PublicKey {}

--- a/lib/src/bip/bip_proposal_type.dart
+++ b/lib/src/bip/bip_proposal_type.dart
@@ -1,0 +1,10 @@
+/// Enum for BIP proposal types
+enum BipProposalType {
+  bip44(44),
+  bip49(49),
+  bip84(84);
+
+  final int proposalNumber;
+
+  const BipProposalType(this.proposalNumber);
+}

--- a/lib/src/cdsa/cdsa.dart
+++ b/lib/src/cdsa/cdsa.dart
@@ -1,4 +1,5 @@
 export 'curve_points.dart';
+export 'curve_type.dart';
 export 'curves.dart';
 export 'ecdsa/ecdsa.dart';
 export 'i_signature.dart';

--- a/lib/src/cdsa/curve_type.dart
+++ b/lib/src/cdsa/curve_type.dart
@@ -1,0 +1,3 @@
+enum CurveType {
+  secp256k1,
+}

--- a/lib/src/cdsa/ecdsa/ecdsa.dart
+++ b/lib/src/cdsa/ecdsa/ecdsa.dart
@@ -2,6 +2,8 @@ export 'ec_curve.dart';
 export 'ec_point.dart';
 export 'ec_private_key.dart';
 export 'ec_public_key.dart';
+export 'secp256k1/secp256k1_private_key.dart';
+export 'secp256k1/secp256k1_public_key.dart';
 export 'signer/ec_signature.dart';
 export 'signer/ecdsa_signer.dart';
 export 'signer/rfc6979.dart';

--- a/lib/src/cdsa/ecdsa/secp256k1/secp256k1_private_key.dart
+++ b/lib/src/cdsa/ecdsa/secp256k1/secp256k1_private_key.dart
@@ -1,0 +1,40 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:equatable/equatable.dart';
+
+/// [Secp256k1PrivateKey] represents [ECPrivateKey] constructed with specific Curve (secp256k1) and chain code.
+class Secp256k1PrivateKey extends Equatable implements IBip32PrivateKey {
+  /// ECDSA Private key used for cryptographic operations, following the secp256k1 curve specification.
+  final ECPrivateKey ecPrivateKey;
+
+  /// A 256-bit (32 bytes) value acting as a component of BIP-32 private key.
+  /// It's used in conjunction with [ecPrivateKey] for generating child private keys.
+  final Uint8List _chainCode;
+
+  const Secp256k1PrivateKey({
+    required this.ecPrivateKey,
+    required Uint8List chainCode,
+  }) : _chainCode = chainCode;
+
+  /// Returns the private key as a byte array.
+  @override
+  Uint8List get bytes => ecPrivateKey.bytes;
+
+  /// Returns the chain code.
+  @override
+  Uint8List get chainCode => _chainCode;
+
+  /// Returns the length of the private key.
+  @override
+  int get length => ECPrivateKey.length;
+
+  /// Returns the public key derived from the private key.
+  @override
+  Secp256k1PublicKey get publicKey {
+    return Secp256k1PublicKey(ecPublicKey: ecPrivateKey.ecPublicKey);
+  }
+
+  @override
+  List<Object?> get props => <Object>[ecPrivateKey, _chainCode];
+}

--- a/lib/src/cdsa/ecdsa/secp256k1/secp256k1_public_key.dart
+++ b/lib/src/cdsa/ecdsa/secp256k1/secp256k1_public_key.dart
@@ -1,0 +1,23 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:equatable/equatable.dart';
+
+/// [Secp256k1PublicKey] represents [ECPublicKey] constructed with specific Curve (secp256k1) and chain code.
+class Secp256k1PublicKey extends Equatable implements IBip32PublicKey {
+  /// ECDSA public key derived from the corresponding private key, following the secp256k1 curve specification.
+  /// This public key is used in the verification process of digital signatures, allowing others to verify the authenticity
+  /// of transactions or messages signed with the associated private key, without compromising the private key itself.
+  final ECPublicKey ecPublicKey;
+
+  const Secp256k1PublicKey({required this.ecPublicKey});
+
+  /// Returns the compressed form of the public key.
+  Uint8List get compressed => ecPublicKey.compressed;
+
+  /// Returns the uncompressed form of the public key.
+  Uint8List get uncompressed => ecPublicKey.uncompressed;
+
+  @override
+  List<Object?> get props => <Object>[ecPublicKey];
+}

--- a/lib/src/config/config.dart
+++ b/lib/src/config/config.dart
@@ -1,0 +1,5 @@
+export 'wallets_config/bip44_wallets_config.dart';
+export 'wallets_config/bip49_wallets_config.dart';
+export 'wallets_config/bip84_wallets_config.dart';
+export 'wallets_config/objects/a_wallet_config.dart';
+export 'wallets_config/objects/legacy_wallet_config.dart';

--- a/lib/src/config/wallets_config/bip44_wallets_config.dart
+++ b/lib/src/config/wallets_config/bip44_wallets_config.dart
@@ -1,0 +1,37 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// [Bip44WalletsConfig] class provides configurations for creating wallets adhering to BIP-44 standards.
+/// Configurations include:
+///   - `derivator`: Algorithm used for key derivation
+///   - `coinIndex`: Index of the coin as per the SLIP44 standard
+///   - `curveType`: Type of the elliptic curve used for key generation
+///   - `purpose`: Type of the BIP proposal
+class Bip44WalletsConfig {
+  static LegacyWalletConfig bitcoin = LegacyWalletConfig(
+    derivator: Secp256k1Derivator(),
+    coinIndex: Slip44.bitcoin,
+    curveType: CurveType.secp256k1,
+    purpose: BipProposalType.bip44,
+  );
+
+  static LegacyWalletConfig ethereum = LegacyWalletConfig(
+    derivator: Secp256k1Derivator(),
+    coinIndex: Slip44.ethereum,
+    curveType: CurveType.secp256k1,
+    purpose: BipProposalType.bip44,
+  );
+
+  static LegacyWalletConfig cosmos = LegacyWalletConfig(
+    derivator: Secp256k1Derivator(),
+    coinIndex: Slip44.cosmos,
+    curveType: CurveType.secp256k1,
+    purpose: BipProposalType.bip44,
+  );
+
+  static LegacyWalletConfig kira = LegacyWalletConfig(
+    derivator: Secp256k1Derivator(),
+    coinIndex: Slip44.kira,
+    curveType: CurveType.secp256k1,
+    purpose: BipProposalType.bip44,
+  );
+}

--- a/lib/src/config/wallets_config/bip49_wallets_config.dart
+++ b/lib/src/config/wallets_config/bip49_wallets_config.dart
@@ -1,0 +1,16 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// [Bip49WalletsConfig] class provides configurations for creating wallets adhering to BIP-49 standards.
+/// Configurations include:
+///   - `derivator`: Algorithm used for key derivation
+///   - `coinIndex`: Index of the coin as per the SLIP44 standard
+///   - `curveType`: Type of the elliptic curve used for key generation
+///   - `purpose`: Type of the BIP proposal
+class Bip49WalletsConfig {
+  static LegacyWalletConfig bitcoin = LegacyWalletConfig(
+    derivator: Secp256k1Derivator(),
+    coinIndex: Slip44.bitcoin,
+    curveType: CurveType.secp256k1,
+    purpose: BipProposalType.bip49,
+  );
+}

--- a/lib/src/config/wallets_config/bip84_wallets_config.dart
+++ b/lib/src/config/wallets_config/bip84_wallets_config.dart
@@ -1,0 +1,16 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// [Bip84WalletsConfig] class provides configurations for creating wallets adhering to BIP-84 standards.
+/// Configurations include:
+///   - `derivator`: Algorithm used for key derivation
+///   - `coinIndex`: Index of the coin as per the SLIP44 standard
+///   - `curveType`: Type of the elliptic curve used for key generation
+///   - `purpose`: Type of the BIP proposal
+class Bip84WalletsConfig {
+  static LegacyWalletConfig bitcoin = LegacyWalletConfig(
+    derivator: Secp256k1Derivator(),
+    coinIndex: Slip44.bitcoin,
+    curveType: CurveType.secp256k1,
+    purpose: BipProposalType.bip84,
+  );
+}

--- a/lib/src/config/wallets_config/objects/a_wallet_config.dart
+++ b/lib/src/config/wallets_config/objects/a_wallet_config.dart
@@ -1,0 +1,13 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:equatable/equatable.dart';
+
+abstract class AWalletConfig extends Equatable {
+  final IDerivator derivator;
+
+  const AWalletConfig({
+    required this.derivator,
+  });
+
+  @override
+  List<Object?> get props => <Object>[derivator];
+}

--- a/lib/src/config/wallets_config/objects/legacy_wallet_config.dart
+++ b/lib/src/config/wallets_config/objects/legacy_wallet_config.dart
@@ -1,0 +1,22 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+class LegacyWalletConfig extends AWalletConfig {
+  final int coinIndex;
+  final CurveType curveType;
+  final BipProposalType purpose;
+
+  const LegacyWalletConfig({
+    required ILegacyDerivator derivator,
+    required this.coinIndex,
+    required this.curveType,
+    required this.purpose,
+  }) : super(derivator: derivator);
+
+  @override
+  ILegacyDerivator get derivator => super.derivator as ILegacyDerivator;
+
+  String get baseDerivationPath => "m/${purpose.proposalNumber}'/$coinIndex'";
+
+  @override
+  List<Object?> get props => <Object>[derivator, coinIndex, curveType, purpose];
+}

--- a/lib/src/slip/slip.dart
+++ b/lib/src/slip/slip.dart
@@ -1,0 +1,1 @@
+export 'slip44.dart';

--- a/lib/src/slip/slip44.dart
+++ b/lib/src/slip/slip44.dart
@@ -1,0 +1,7 @@
+/// Implementation of SLIP-0044, which defines the BIP-44 coin indexes.
+class Slip44 {
+  static const int bitcoin = 0;
+  static const int ethereum = 60;
+  static const int cosmos = 118;
+  static const int kira = 118;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cryptography_utils
 description: "Cryptography utils"
-version: 0.0.4
+version: 0.0.5
 
 environment:
   sdk: ">=3.2.2"

--- a/test/bip/bip32/derivation_path/legacy_derivation_path/legacy_derivation_path_element_test.dart
+++ b/test/bip/bip32/derivation_path/legacy_derivation_path/legacy_derivation_path_element_test.dart
@@ -1,0 +1,107 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Tests of LegacyDerivationPathElement.parse() constructor', () {
+    test('Should [return LegacyDerivationPathElement] from [HARDENED path element as String]', () {
+      // Act
+      LegacyDerivationPathElement actualLegacyDerivationPathElement = LegacyDerivationPathElement.parse("44'");
+
+      // Assert
+      LegacyDerivationPathElement expectedLegacyDerivationPathElement = const LegacyDerivationPathElement(hardenedBool: true, index: 2147483692, value: "44'");
+
+      expect(actualLegacyDerivationPathElement, expectedLegacyDerivationPathElement);
+    });
+
+    test('Should [return LegacyDerivationPathElement] from [NOT HARDENED path element as String]', () {
+      // Act
+      LegacyDerivationPathElement actualLegacyDerivationPathElement = LegacyDerivationPathElement.parse('0');
+
+      // Assert
+      LegacyDerivationPathElement expectedLegacyDerivationPathElement = const LegacyDerivationPathElement(hardenedBool: false, index: 0, value: '0');
+
+      expect(actualLegacyDerivationPathElement, expectedLegacyDerivationPathElement);
+    });
+
+    test('Should [throw FormatException] if provided [path element INVALID]', () {
+      // Assert
+      expect(() => LegacyDerivationPathElement.parse('0x'), throwsFormatException);
+    });
+  });
+
+  group('Tests of LegacyDerivationPathElement.isHardened getter', () {
+    test('Should [return TRUE] if [path element HARDENED]', () {
+      // Arrange
+      LegacyDerivationPathElement derivationPathElement = const LegacyDerivationPathElement(hardenedBool: true, index: 0, value: "0'");
+
+      // Act
+      bool actualHardenedBool = derivationPathElement.isHardened;
+
+      // Assert
+      expect(actualHardenedBool, true);
+    });
+
+    test('Should [return FALSE] if [path element NOT HARDENED]', () {
+      // Arrange
+      LegacyDerivationPathElement derivationPathElement = const LegacyDerivationPathElement(hardenedBool: false, index: 0, value: '0');
+
+      // Act
+      bool actualHardenedBool = derivationPathElement.isHardened;
+
+      // Assert
+      expect(actualHardenedBool, false);
+    });
+  });
+
+  group('Tests of LegacyDerivationPathElement.toBytes()', () {
+    test('Should [return BYTES] constructed from LegacyDerivationPathElement index (zero value)', () {
+      // Arrange
+      LegacyDerivationPathElement derivationPathElement = const LegacyDerivationPathElement(hardenedBool: false, index: 0, value: '0');
+
+      // Act
+      List<int> actualBytes = derivationPathElement.toBytes();
+
+      // Assert
+      List<int> expectedBytes = <int>[0, 0, 0, 0];
+      expect(actualBytes, expectedBytes);
+    });
+
+    test('Should [return BYTES] constructed from LegacyDerivationPathElement index (non-zero value)', () {
+      // Arrange
+      LegacyDerivationPathElement derivationPathElement = const LegacyDerivationPathElement(hardenedBool: false, index: 2147483692, value: '44');
+
+      // Act
+      List<int> actualBytes = derivationPathElement.toBytes();
+
+      // Assert
+      List<int> expectedBytes = <int>[128, 0, 0, 44];
+      expect(actualBytes, expectedBytes);
+    });
+  });
+
+  group('Test of LegacyDerivationPathElement.toString()', () {
+    test('Should [return String] identifying (HARDENED path element)', () {
+      // Arrange
+      LegacyDerivationPathElement derivationPathElement = const LegacyDerivationPathElement(hardenedBool: true, index: 2147483692, value: "44'");
+
+      // Act
+      String actualString = derivationPathElement.toString();
+
+      // Assert
+      String expectedString = "44'";
+      expect(actualString, expectedString);
+    });
+
+    test('Should [return String] identifying (NOT HARDENED path element)', () {
+      // Arrange
+      LegacyDerivationPathElement derivationPathElement = const LegacyDerivationPathElement(hardenedBool: false, index: 44, value: '44');
+
+      // Act
+      String actualString = derivationPathElement.toString();
+
+      // Assert
+      String expectedString = '44';
+      expect(actualString, expectedString);
+    });
+  });
+}

--- a/test/bip/bip32/derivation_path/legacy_derivation_path/legacy_derivation_path_test.dart
+++ b/test/bip/bip32/derivation_path/legacy_derivation_path/legacy_derivation_path_test.dart
@@ -1,0 +1,83 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Tests of LegacyDerivationPath.parse() constructor', () {
+    test('Should [return LegacyDerivationPath] object parsed from [VALID derivation path] (WITHOUT trailing slash)', () {
+      // Act
+      LegacyDerivationPath actualLegacyDerivationPath = LegacyDerivationPath.parse("m/44'/60'/0'/0/0");
+
+      // Assert
+      LegacyDerivationPath expectedLegacyDerivationPath = LegacyDerivationPath(pathElements: const <LegacyDerivationPathElement>[
+        LegacyDerivationPathElement(hardenedBool: true, index: 2147483692, value: "44'"),
+        LegacyDerivationPathElement(hardenedBool: true, index: 2147483708, value: "60'"),
+        LegacyDerivationPathElement(hardenedBool: true, index: 2147483648, value: "0'"),
+        LegacyDerivationPathElement(hardenedBool: false, index: 0, value: '0'),
+        LegacyDerivationPathElement(hardenedBool: false, index: 0, value: '0'),
+      ]);
+
+      expect(actualLegacyDerivationPath, expectedLegacyDerivationPath);
+    });
+
+    test('Should [return LegacyDerivationPath] object parsed from [VALID derivation path] (WITH trailing slash)', () {
+      // Act
+      LegacyDerivationPath actualLegacyDerivationPath = LegacyDerivationPath.parse("m/44'/60'/0'/0/0/");
+
+      // Assert
+      LegacyDerivationPath expectedLegacyDerivationPath = LegacyDerivationPath(pathElements: const <LegacyDerivationPathElement>[
+        LegacyDerivationPathElement(hardenedBool: true, index: 2147483692, value: "44'"),
+        LegacyDerivationPathElement(hardenedBool: true, index: 2147483708, value: "60'"),
+        LegacyDerivationPathElement(hardenedBool: true, index: 2147483648, value: "0'"),
+        LegacyDerivationPathElement(hardenedBool: false, index: 0, value: '0'),
+        LegacyDerivationPathElement(hardenedBool: false, index: 0, value: '0'),
+      ]);
+
+      expect(actualLegacyDerivationPath, expectedLegacyDerivationPath);
+    });
+
+    test('Should [throw FormatException] if derivation path contains invalid element', () {
+      // Act
+      void actualLegacyDerivationPath() => LegacyDerivationPath.parse("44'/60'/invalid_element'/0/0");
+
+      // Assert
+      expect(actualLegacyDerivationPath, throwsFormatException);
+    });
+
+    test('Should [throw FormatException] if derivation path does not contain master element ("m/" prefix)', () {
+      // Act
+      void actualLegacyDerivationPath() => LegacyDerivationPath.parse("44'/60'/0'/0/0");
+
+      // Assert
+      expect(actualLegacyDerivationPath, throwsFormatException);
+    });
+
+    test('Should [throw FormatException] if derivation path is empty', () {
+      // Act
+      void actualLegacyDerivationPath() => LegacyDerivationPath.parse('');
+
+      // Assert
+      expect(actualLegacyDerivationPath, throwsFormatException);
+    });
+  });
+
+  group('Tests of LegacyDerivationPath.toString()', () {
+    test('Should [return LegacyDerivationPath] as String', () {
+      // Arrange
+      LegacyDerivationPath actualLegacyDerivationPath = LegacyDerivationPath(pathElements: const <LegacyDerivationPathElement>[
+        LegacyDerivationPathElement(hardenedBool: true, index: 2147483692, value: "44'"),
+        LegacyDerivationPathElement(hardenedBool: true, index: 2147483708, value: "60'"),
+        LegacyDerivationPathElement(hardenedBool: true, index: 2147483648, value: "0'"),
+        LegacyDerivationPathElement(hardenedBool: false, index: 0, value: '0'),
+        LegacyDerivationPathElement(hardenedBool: false, index: 0, value: '0'),
+      ]);
+
+      // Act
+      String actualLegacyDerivationPathString = actualLegacyDerivationPath.toString();
+
+      // Assert
+      String expectedLegacyDerivationPathString = "m/44'/60'/0'/0/0";
+
+      expect(actualLegacyDerivationPathString, expectedLegacyDerivationPathString);
+    });
+  });
+}

--- a/test/bip/bip32/derivators/legacy_derivators/secp256k1_derivator_test.dart
+++ b/test/bip/bip32/derivators/legacy_derivators/secp256k1_derivator_test.dart
@@ -1,0 +1,291 @@
+import 'dart:convert';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Secp256k1Derivator actualSecp256k1Derivator = Secp256k1Derivator();
+  Mnemonic actualMnemonic = Mnemonic.fromString(
+      'require point property company tongue busy bench burden caution gadget knee glance thought bulk assist month cereal report quarter tool section often require shield');
+
+  group('Secp256k1Derivator.derivePath()', () {
+    test("Should [return Secp256k1PrivateKey] constructed from mnemonic and derivation path (m/44'/)", () async {
+      // Arrange
+      LegacyDerivationPath actualLegacyDerivationPath = LegacyDerivationPath.parse("m/44'/");
+
+      // Act
+      Secp256k1PrivateKey actualSecp256k1PrivateKey = await actualSecp256k1Derivator.derivePath(actualMnemonic, actualLegacyDerivationPath);
+
+      // Assert
+      Secp256k1PrivateKey expectedSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('bBRorINnDOQdK1WZf79vroWQHTPqtzASttTKd9zj8DQ='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('79831946198650946731958597072964003247551220898694366462475661038263959258621'),
+        ),
+      );
+
+      expect(actualSecp256k1PrivateKey, expectedSecp256k1PrivateKey);
+    });
+
+    test("Should [return Secp256k1PrivateKey] constructed from mnemonic and derivation path (m/44'/60'/)", () async {
+      // Arrange
+      LegacyDerivationPath actualLegacyDerivationPath = LegacyDerivationPath.parse("m/44'/60'/");
+
+      // Act
+      Secp256k1PrivateKey actualSecp256k1PrivateKey = await actualSecp256k1Derivator.derivePath(actualMnemonic, actualLegacyDerivationPath);
+
+      // Assert
+      Secp256k1PrivateKey expectedSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('qEamIw6rnFvaXJCnzkIP7knN1l+8jTwYrrUWH78PRvs='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('33468663939336344008642663460868643449058067978731001309522127228111822578589'),
+        ),
+      );
+
+      expect(actualSecp256k1PrivateKey, expectedSecp256k1PrivateKey);
+    });
+
+    test("Should [return Secp256k1PrivateKey] constructed from mnemonic and derivation path (m/44'/60'/0'/)", () async {
+      // Arrange
+      LegacyDerivationPath actualLegacyDerivationPath = LegacyDerivationPath.parse("m/44'/60'/0'/");
+
+      // Act
+      Secp256k1PrivateKey actualSecp256k1PrivateKey = await actualSecp256k1Derivator.derivePath(actualMnemonic, actualLegacyDerivationPath);
+
+      // Assert
+      Secp256k1PrivateKey expectedSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('5gvokyLRAipECLgT5AnkPLX6thREo+E27t5wUBpna9w='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('34110929557805538687207758350694761629513303450048015188759646123112870087187'),
+        ),
+      );
+
+      expect(actualSecp256k1PrivateKey, expectedSecp256k1PrivateKey);
+    });
+
+    test("Should [return Secp256k1PrivateKey] constructed from mnemonic and derivation path (m/44'/60'/0'/0/)", () async {
+      // Arrange
+      LegacyDerivationPath actualLegacyDerivationPath = LegacyDerivationPath.parse("m/44'/60'/0'/0/");
+
+      // Act
+      Secp256k1PrivateKey actualSecp256k1PrivateKey = await actualSecp256k1Derivator.derivePath(actualMnemonic, actualLegacyDerivationPath);
+
+      // Assert
+      Secp256k1PrivateKey expectedSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('FK0bd1Z1KEZpXlZ45+GufE0HsweNVoh7EkZndgnxmVA='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('105108244234952036067739519086050878250157101554789072999465154826127982006038'),
+        ),
+      );
+
+      expect(actualSecp256k1PrivateKey, expectedSecp256k1PrivateKey);
+    });
+
+    test("Should [return Secp256k1PrivateKey] constructed from mnemonic and derivation path (m/44'/60'/0'/0/0)", () async {
+      // Arrange
+      LegacyDerivationPath actualLegacyDerivationPath = LegacyDerivationPath.parse("m/44'/60'/0'/0/0");
+
+      // Act
+      Secp256k1PrivateKey actualSecp256k1PrivateKey = await actualSecp256k1Derivator.derivePath(actualMnemonic, actualLegacyDerivationPath);
+
+      // Assert
+      Secp256k1PrivateKey expectedSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('YsN74zJ6p9/kjsFCM5UUBq470XR3CEssHXyawdn7xBw='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('91850346642365090382529827989594437164777469345439968194889143349494450093883'),
+        ),
+      );
+
+      expect(actualSecp256k1PrivateKey, expectedSecp256k1PrivateKey);
+    });
+
+    test("Should [return Secp256k1PrivateKey] constructed from mnemonic and derivation path (m/44'/60'/0'/0/1)", () async {
+      // Arrange
+      LegacyDerivationPath actualLegacyDerivationPath = LegacyDerivationPath.parse("m/44'/60'/0'/0/1");
+
+      // Act
+      Secp256k1PrivateKey actualSecp256k1PrivateKey = await actualSecp256k1Derivator.derivePath(actualMnemonic, actualLegacyDerivationPath);
+
+      // Assert
+      Secp256k1PrivateKey expectedSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('3VL5eTTh8pFkN3ItX3mfcHrTbdRoGjyc7g2xVqBE20I='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('48321682786873812630811942224115257386621604474116153286196688270143935383344'),
+        ),
+      );
+
+      expect(actualSecp256k1PrivateKey, expectedSecp256k1PrivateKey);
+    });
+  });
+
+  group('Secp256k1Derivator.deriveMasterKey()', () {
+    test('Should [return Secp256k1PrivateKey] constructed from mnemonic', () async {
+      // Act
+      Secp256k1PrivateKey actualSecp256k1PrivateKey = await actualSecp256k1Derivator.deriveMasterKey(actualMnemonic);
+
+      // Assert
+      Secp256k1PrivateKey expectedSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('UNH2aBl1uMkP+S/i5vZVK8tC2uODdICFW0hrpY8Zrbk='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('15864759622800253937020257025334897817812874204769186060960403729801414344643'),
+        ),
+      );
+
+      expect(actualSecp256k1PrivateKey, expectedSecp256k1PrivateKey);
+    });
+  });
+
+  group('Secp256k1Derivator.deriveChildKey()', () {
+    test("Should [return Secp256k1PrivateKey] constructed from Secp256k1PrivateKey and DerivationPathElement (m/ -> m/44'/)", () {
+      // Arrange
+      LegacyDerivationPathElement actualDerivationPathElement = LegacyDerivationPathElement.parse("44'");
+
+      // Master private key
+      Secp256k1PrivateKey actualSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('UNH2aBl1uMkP+S/i5vZVK8tC2uODdICFW0hrpY8Zrbk='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('15864759622800253937020257025334897817812874204769186060960403729801414344643'),
+        ),
+      );
+
+      // Act
+      Secp256k1PrivateKey actualChildSecp256k1PrivateKey = actualSecp256k1Derivator.deriveChildKey(actualSecp256k1PrivateKey, actualDerivationPathElement);
+
+      // Assert
+      // Private key derived from master private key and 44' derivation path element
+      Secp256k1PrivateKey expectedChildSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('bBRorINnDOQdK1WZf79vroWQHTPqtzASttTKd9zj8DQ='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('79831946198650946731958597072964003247551220898694366462475661038263959258621'),
+        ),
+      );
+
+      expect(actualChildSecp256k1PrivateKey, expectedChildSecp256k1PrivateKey);
+    });
+
+    test("Should [return Secp256k1PrivateKey] constructed from Secp256k1PrivateKey and DerivationPathElement (m/44'/ -> m/44'/60'/)", () {
+      // Arrange
+      LegacyDerivationPathElement actualDerivationPathElement = LegacyDerivationPathElement.parse("60'");
+
+      // Private key derived from master private key and m/44' derivation path (value calculated in the previous test)
+      Secp256k1PrivateKey actualSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('bBRorINnDOQdK1WZf79vroWQHTPqtzASttTKd9zj8DQ='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('79831946198650946731958597072964003247551220898694366462475661038263959258621'),
+        ),
+      );
+
+      // Act
+      Secp256k1PrivateKey actualChildSecp256k1PrivateKey = actualSecp256k1Derivator.deriveChildKey(actualSecp256k1PrivateKey, actualDerivationPathElement);
+
+      // Assert
+      // Private key derived from master private key and m/44'/60' derivation path
+      Secp256k1PrivateKey expectedChildSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('qEamIw6rnFvaXJCnzkIP7knN1l+8jTwYrrUWH78PRvs='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('33468663939336344008642663460868643449058067978731001309522127228111822578589'),
+        ),
+      );
+
+      expect(actualChildSecp256k1PrivateKey, expectedChildSecp256k1PrivateKey);
+    });
+
+    test("Should [return Secp256k1PrivateKey] constructed from Secp256k1PrivateKey and DerivationPathElement (m/44'/60'/ -> m/44'/60'/0'/)", () {
+      // Arrange
+      LegacyDerivationPathElement actualDerivationPathElement = LegacyDerivationPathElement.parse("0'");
+
+      // Private key derived from master private key and m/44'/60' derivation path (value calculated in the previous test)
+      Secp256k1PrivateKey actualSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('qEamIw6rnFvaXJCnzkIP7knN1l+8jTwYrrUWH78PRvs='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('33468663939336344008642663460868643449058067978731001309522127228111822578589'),
+        ),
+      );
+
+      // Act
+      Secp256k1PrivateKey actualChildSecp256k1PrivateKey = actualSecp256k1Derivator.deriveChildKey(actualSecp256k1PrivateKey, actualDerivationPathElement);
+
+      // Assert
+      // Private key derived from master private key and m/44'/60'/0' derivation path
+      Secp256k1PrivateKey expectedChildSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('5gvokyLRAipECLgT5AnkPLX6thREo+E27t5wUBpna9w='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('34110929557805538687207758350694761629513303450048015188759646123112870087187'),
+        ),
+      );
+
+      expect(actualChildSecp256k1PrivateKey, expectedChildSecp256k1PrivateKey);
+    });
+
+    test("Should [return Secp256k1PrivateKey] constructed from Secp256k1PrivateKey and DerivationPathElement (m/44'/60'/0'/ -> m/44'/60'/0'/0/)", () {
+      // Arrange
+      LegacyDerivationPathElement actualDerivationPathElement = LegacyDerivationPathElement.parse('0');
+
+      // Private key derived from master private key and m/44'/60'/0' derivation path (value calculated in the previous test)
+      Secp256k1PrivateKey actualSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('5gvokyLRAipECLgT5AnkPLX6thREo+E27t5wUBpna9w='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('34110929557805538687207758350694761629513303450048015188759646123112870087187'),
+        ),
+      );
+
+      // Act
+      Secp256k1PrivateKey actualChildSecp256k1PrivateKey = actualSecp256k1Derivator.deriveChildKey(actualSecp256k1PrivateKey, actualDerivationPathElement);
+
+      // Assert
+      // Private key derived from master private key and m/44'/60'/0'/0 derivation path
+      Secp256k1PrivateKey expectedChildSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('FK0bd1Z1KEZpXlZ45+GufE0HsweNVoh7EkZndgnxmVA='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('105108244234952036067739519086050878250157101554789072999465154826127982006038'),
+        ),
+      );
+
+      expect(actualChildSecp256k1PrivateKey, expectedChildSecp256k1PrivateKey);
+    });
+
+    test("Should [return Secp256k1PrivateKey] constructed from Secp256k1PrivateKey and DerivationPathElement (m/44'/60'/0'/0/ -> m/44'/60'/0'/0/0)", () {
+      // Arrange
+      LegacyDerivationPathElement actualDerivationPathElement = LegacyDerivationPathElement.parse('0');
+
+      // Private key derived from master private key and m/44'/60'/0'/0 derivation path (value calculated in the previous test)
+      Secp256k1PrivateKey actualSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('FK0bd1Z1KEZpXlZ45+GufE0HsweNVoh7EkZndgnxmVA='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('105108244234952036067739519086050878250157101554789072999465154826127982006038'),
+        ),
+      );
+
+      // Act
+      Secp256k1PrivateKey actualChildSecp256k1PrivateKey = actualSecp256k1Derivator.deriveChildKey(actualSecp256k1PrivateKey, actualDerivationPathElement);
+
+      // Assert
+      // Private key derived from master private key and m/44'/60'/0'/0/0 derivation path
+      Secp256k1PrivateKey expectedChildSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('YsN74zJ6p9/kjsFCM5UUBq470XR3CEssHXyawdn7xBw='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('91850346642365090382529827989594437164777469345439968194889143349494450093883'),
+        ),
+      );
+
+      expect(actualChildSecp256k1PrivateKey, expectedChildSecp256k1PrivateKey);
+    });
+  });
+}

--- a/test/bip/bip32/hd_wallet/legacy_hd_wallet_test.dart
+++ b/test/bip/bip32/hd_wallet/legacy_hd_wallet_test.dart
@@ -1,0 +1,227 @@
+import 'dart:convert';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Mnemonic mnemonic = Mnemonic.fromString(
+      'require point property company tongue busy bench burden caution gadget knee glance thought bulk assist month cereal report quarter tool section often require shield');
+
+  group('Tests of LegacyHDWallet.fromMnemonic()', () {
+    test('Should [return LegacyHDWallet] from given mnemonic (BIP44-Kira)', () async {
+      // Act
+      LegacyHDWallet actualKiraWallet = await LegacyHDWallet.fromMnemonic(
+        mnemonic: mnemonic,
+        walletConfig: Bip44WalletsConfig.kira,
+        derivationPathString: "m/44'/118'/0'/0/0",
+      );
+
+      // Assert
+      LegacyHDWallet expectedKiraWallet = LegacyHDWallet(
+        walletConfig: Bip44WalletsConfig.kira,
+        privateKey: Secp256k1PrivateKey(
+          chainCode: base64Decode('atgf2JWMxW014Hby5ccSn5NlRKQvIV2jvsdtcN3Eb8I='),
+          ecPrivateKey: ECPrivateKey(
+            CurvePoints.generatorSecp256k1,
+            BigInt.parse('25933686250415448129536663355227060923413846494721047098076326567395973050293'),
+          ),
+        ),
+        publicKey: Secp256k1PublicKey(
+          ecPublicKey: ECPublicKey(
+            CurvePoints.generatorSecp256k1,
+            ECPoint(
+              curve: Curves.secp256k1,
+              n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+              x: BigInt.parse('103541830980023606809613093633067363502594290705821036222890728111110906420509'),
+              y: BigInt.parse('75808906644622006047938879719654783679105512040910575915102508326553703647166'),
+              z: BigInt.parse('3190226348536498292494465017020441737630476122313049345633869118655223224149'),
+            ),
+          ),
+        ),
+        derivationPath: LegacyDerivationPath.parse("m/44'/118'/0'/0/0"),
+      );
+
+      expect(actualKiraWallet, expectedKiraWallet);
+    });
+
+    test('Should [return LegacyHDWallet] from given mnemonic (BIP44-Cosmos)', () async {
+      // Act
+      LegacyHDWallet actualCosmosWallet = await LegacyHDWallet.fromMnemonic(
+        mnemonic: mnemonic,
+        walletConfig: Bip44WalletsConfig.cosmos,
+        derivationPathString: "m/44'/118'/0'/0/0",
+      );
+
+      // Assert
+      LegacyHDWallet expectedCosmosWallet = LegacyHDWallet(
+        walletConfig: Bip44WalletsConfig.cosmos,
+        privateKey: Secp256k1PrivateKey(
+          chainCode: base64Decode('atgf2JWMxW014Hby5ccSn5NlRKQvIV2jvsdtcN3Eb8I='),
+          ecPrivateKey: ECPrivateKey(
+            CurvePoints.generatorSecp256k1,
+            BigInt.parse('25933686250415448129536663355227060923413846494721047098076326567395973050293'),
+          ),
+        ),
+        publicKey: Secp256k1PublicKey(
+          ecPublicKey: ECPublicKey(
+            CurvePoints.generatorSecp256k1,
+            ECPoint(
+              curve: Curves.secp256k1,
+              n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+              x: BigInt.parse('103541830980023606809613093633067363502594290705821036222890728111110906420509'),
+              y: BigInt.parse('75808906644622006047938879719654783679105512040910575915102508326553703647166'),
+              z: BigInt.parse('3190226348536498292494465017020441737630476122313049345633869118655223224149'),
+            ),
+          ),
+        ),
+        derivationPath: LegacyDerivationPath.parse("m/44'/118'/0'/0/0"),
+      );
+
+      expect(actualCosmosWallet, expectedCosmosWallet);
+    });
+
+    test('Should [return LegacyHDWallet] from given mnemonic (BIP44-Ethereum)', () async {
+      // Act
+      LegacyHDWallet actualEthereumWallet = await LegacyHDWallet.fromMnemonic(
+        mnemonic: mnemonic,
+        walletConfig: Bip44WalletsConfig.ethereum,
+        derivationPathString: "m/44'/60'/0'/0/0",
+      );
+
+      // Assert
+      LegacyHDWallet expectedEthereumWallet = LegacyHDWallet(
+        walletConfig: Bip44WalletsConfig.ethereum,
+        privateKey: Secp256k1PrivateKey(
+          chainCode: base64Decode('YsN74zJ6p9/kjsFCM5UUBq470XR3CEssHXyawdn7xBw='),
+          ecPrivateKey: ECPrivateKey(
+            CurvePoints.generatorSecp256k1,
+            BigInt.parse('91850346642365090382529827989594437164777469345439968194889143349494450093883'),
+          ),
+        ),
+        publicKey: Secp256k1PublicKey(
+          ecPublicKey: ECPublicKey(
+            CurvePoints.generatorSecp256k1,
+            ECPoint(
+              curve: Curves.secp256k1,
+              n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+              x: BigInt.parse('49844093485842753019501723164709087800134847594852664670182601545797061237061'),
+              y: BigInt.parse('102584019795063234624860865414832132871049165551248963828805190591824528686504'),
+              z: BigInt.parse('33112508886275853310422687256511308836721055527980470378416551104097868981749'),
+            ),
+          ),
+        ),
+        derivationPath: LegacyDerivationPath.parse("m/44'/60'/0'/0/0"),
+      );
+
+      expect(actualEthereumWallet, expectedEthereumWallet);
+    });
+
+    test('Should [return LegacyHDWallet] from given mnemonic (BIP44-Bitcoin)', () async {
+      // Act
+      LegacyHDWallet actualBitcoinBip44Wallet = await LegacyHDWallet.fromMnemonic(
+        mnemonic: mnemonic,
+        walletConfig: Bip44WalletsConfig.bitcoin,
+        derivationPathString: "m/44'/0'/0'/0/0",
+      );
+
+      // Assert
+      LegacyHDWallet expectedBitcoinBip44Wallet = LegacyHDWallet(
+        walletConfig: Bip44WalletsConfig.bitcoin,
+        privateKey: Secp256k1PrivateKey(
+          chainCode: base64Decode('rEcUq915xZMcSVN9UIfhWIf7c+cb9fURwnXSJ59fbhs='),
+          ecPrivateKey: ECPrivateKey(
+            CurvePoints.generatorSecp256k1,
+            BigInt.parse('82377503398124971005475108599523902661393087907602410456433373035270068286106'),
+          ),
+        ),
+        publicKey: Secp256k1PublicKey(
+          ecPublicKey: ECPublicKey(
+            CurvePoints.generatorSecp256k1,
+            ECPoint(
+              curve: Curves.secp256k1,
+              n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+              x: BigInt.parse('38336877429777144060267786813855742566762755003810222330370030177500553175552'),
+              y: BigInt.parse('43563831752869961512099662435070760564842488811079803779798870455459619618648'),
+              z: BigInt.parse('84221606303351351252384011276733806130312533127115701665238461934963837834470'),
+            ),
+          ),
+        ),
+        derivationPath: LegacyDerivationPath.parse("m/44'/0'/0'/0/0"),
+      );
+
+      expect(actualBitcoinBip44Wallet, expectedBitcoinBip44Wallet);
+    });
+
+    test('Should [return LegacyHDWallet] from given mnemonic (BIP49-Bitcoin)', () async {
+      // Act
+      LegacyHDWallet actualBitcoinBip49Wallet = await LegacyHDWallet.fromMnemonic(
+        mnemonic: mnemonic,
+        walletConfig: Bip49WalletsConfig.bitcoin,
+        derivationPathString: "m/49'/0'/0'/0/0",
+      );
+
+      // Assert
+      LegacyHDWallet expectedBitcoinBip49Wallet = LegacyHDWallet(
+        walletConfig: Bip49WalletsConfig.bitcoin,
+        privateKey: Secp256k1PrivateKey(
+          chainCode: base64Decode('dD+m4pyYe3edlY9ZDNDpe370dwMmGNF2ihkMDXjYSpY='),
+          ecPrivateKey: ECPrivateKey(
+            CurvePoints.generatorSecp256k1,
+            BigInt.parse('94791086327829028717275008054464607695206537392279157300063391421050953013739'),
+          ),
+        ),
+        publicKey: Secp256k1PublicKey(
+          ecPublicKey: ECPublicKey(
+            CurvePoints.generatorSecp256k1,
+            ECPoint(
+              curve: Curves.secp256k1,
+              n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+              x: BigInt.parse('45598833024007063412331531275003851810927383922680420932075021036000176892257'),
+              y: BigInt.parse('52075805451846365275495005964097842681620553159632658097877797800509943385562'),
+              z: BigInt.parse('11902898874332229604673834019199903475888972972060602920606280067238874780442'),
+            ),
+          ),
+        ),
+        derivationPath: LegacyDerivationPath.parse("m/49'/0'/0'/0/0"),
+      );
+
+      expect(actualBitcoinBip49Wallet, expectedBitcoinBip49Wallet);
+    });
+
+    test('Should [return LegacyHDWallet] from given mnemonic (BIP84-Bitcoin)', () async {
+      // Act
+      LegacyHDWallet actualBitcoinBip84Wallet = await LegacyHDWallet.fromMnemonic(
+        mnemonic: mnemonic,
+        walletConfig: Bip84WalletsConfig.bitcoin,
+        derivationPathString: "m/84'/0'/0'/0/0",
+      );
+
+      // Assert
+      LegacyHDWallet expectedBitcoinBip84Wallet = LegacyHDWallet(
+        walletConfig: Bip84WalletsConfig.bitcoin,
+        privateKey: Secp256k1PrivateKey(
+          chainCode: base64Decode('HmhuNs2LO3+/SpMIb4FCOCRlS5Ym+ACIprpAAmG4zMI='),
+          ecPrivateKey: ECPrivateKey(
+            CurvePoints.generatorSecp256k1,
+            BigInt.parse('104431983138007662112969845964787088318479940099811565105163559790396390283107'),
+          ),
+        ),
+        publicKey: Secp256k1PublicKey(
+          ecPublicKey: ECPublicKey(
+            CurvePoints.generatorSecp256k1,
+            ECPoint(
+              curve: Curves.secp256k1,
+              n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+              x: BigInt.parse('76703126420722322007634345723463650715654444727861292197619275780698078484198'),
+              y: BigInt.parse('74654274679389979607131077993714677055519561275235266585538223878569670773020'),
+              z: BigInt.parse('40734431342056095760694605795848451157672234281365399275614292579983211792826'),
+            ),
+          ),
+        ),
+        derivationPath: LegacyDerivationPath.parse("m/84'/0'/0'/0/0"),
+      );
+
+      expect(actualBitcoinBip84Wallet, expectedBitcoinBip84Wallet);
+    });
+  });
+}

--- a/test/cdsa/ecdsa/secp256k1/secp256k1_private_key_test.dart
+++ b/test/cdsa/ecdsa/secp256k1/secp256k1_private_key_test.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Tests of Secp256k1PrivateKey.bytes getter', () {
+    test('Should [return bytes] representing Secp256k1PrivateKey', () {
+      // Arrange
+      Secp256k1PrivateKey actualSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('UNH2aBl1uMkP+S/i5vZVK8tC2uODdICFW0hrpY8Zrbk='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('15864759622800253937020257025334897817812874204769186060960403729801414344643'),
+        ),
+      );
+
+      // Act
+      Uint8List actualPrivateKeyBytes = actualSecp256k1PrivateKey.bytes;
+
+      // Assert
+      Uint8List expectedPrivateKeyBytes = base64Decode('IxMiv7h+lmU8ouyK8Ds+wP5EL/n1Kv0TKJft3E0Kf8M=');
+
+      expect(actualPrivateKeyBytes, expectedPrivateKeyBytes);
+    });
+  });
+
+  group('Tests of Secp256k1PrivateKey.chainCode getter', () {
+    test('Should [return bytes] representing Secp256k1PrivateKey chain code', () {
+      // Arrange
+      Secp256k1PrivateKey actualSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('UNH2aBl1uMkP+S/i5vZVK8tC2uODdICFW0hrpY8Zrbk='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('15864759622800253937020257025334897817812874204769186060960403729801414344643'),
+        ),
+      );
+
+      // Act
+      Uint8List actualChainCode = actualSecp256k1PrivateKey.chainCode;
+
+      // Assert
+      Uint8List expectedChainCode = base64Decode('UNH2aBl1uMkP+S/i5vZVK8tC2uODdICFW0hrpY8Zrbk=');
+
+      expect(actualChainCode, expectedChainCode);
+    });
+  });
+
+  group('Tests of Secp256k1PrivateKey.length getter', () {
+    test('Should [return length] of Secp256k1PrivateKey', () {
+      // Arrange
+      Secp256k1PrivateKey actualSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('UNH2aBl1uMkP+S/i5vZVK8tC2uODdICFW0hrpY8Zrbk='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('15864759622800253937020257025334897817812874204769186060960403729801414344643'),
+        ),
+      );
+
+      // Act
+      int actualPrivateKeyLength = actualSecp256k1PrivateKey.length;
+
+      // Assert
+      int expectedPrivateKeyLength = 32;
+
+      expect(actualPrivateKeyLength, expectedPrivateKeyLength);
+    });
+  });
+
+  group('Tests of Secp256k1PrivateKey.publicKey getter', () {
+    test('Should [return Secp256k1PublicKey] constructed from Secp256k1PrivateKey', () {
+      // Arrange
+      Secp256k1PrivateKey actualSecp256k1PrivateKey = Secp256k1PrivateKey(
+        chainCode: base64Decode('UNH2aBl1uMkP+S/i5vZVK8tC2uODdICFW0hrpY8Zrbk='),
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('15864759622800253937020257025334897817812874204769186060960403729801414344643'),
+        ),
+      );
+
+      // Act
+      Secp256k1PublicKey actualSecp256k1PublicKey = actualSecp256k1PrivateKey.publicKey;
+
+      // Assert
+      Secp256k1PublicKey expectedSecp256k1PublicKey = Secp256k1PublicKey(
+        ecPublicKey: ECPublicKey(
+          CurvePoints.generatorSecp256k1,
+          ECPoint(
+            curve: Curves.secp256k1,
+            n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+            x: BigInt.parse('109809582697629541179477143463768131161650648020283737506803606109779771350309'),
+            y: BigInt.parse('93904199375389538639503047221917403320671286887529822165996195593332713512966'),
+            z: BigInt.parse('15114296647857780461657875995579731758281183768828053400819025202844531705682'),
+          ),
+        ),
+      );
+
+      expect(actualSecp256k1PublicKey, expectedSecp256k1PublicKey);
+    });
+  });
+}

--- a/test/cdsa/ecdsa/secp256k1/secp256k1_public_key_test.dart
+++ b/test/cdsa/ecdsa/secp256k1/secp256k1_public_key_test.dart
@@ -1,0 +1,59 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Tests of Secp256k1PublicKey.compressed getter', () {
+    test('Should [return bytes] representing [COMPRESSED Secp256k1PublicKey]', () {
+      // Arrange
+      Secp256k1PublicKey actualSecp256k1publicKey = Secp256k1PublicKey(
+        ecPublicKey: ECPublicKey(
+          CurvePoints.generatorSecp256k1,
+          ECPoint(
+            curve: Curves.secp256k1,
+            n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+            x: BigInt.parse('109809582697629541179477143463768131161650648020283737506803606109779771350309'),
+            y: BigInt.parse('93904199375389538639503047221917403320671286887529822165996195593332713512966'),
+            z: BigInt.parse('15114296647857780461657875995579731758281183768828053400819025202844531705682'),
+          ),
+        ),
+      );
+
+      // Act
+      Uint8List actualCompressedPublicKey = actualSecp256k1publicKey.compressed;
+
+      // Assert
+      Uint8List expectedCompressedPublicKey = base64Decode('Ar+tLoQUarMHBlWt2YHvheCerhvBi3VacJya8XNUx2Yj');
+
+      expect(actualCompressedPublicKey, expectedCompressedPublicKey);
+    });
+  });
+
+  group('Tests of Secp256k1PublicKey.uncompressed getter', () {
+    test('Should [return bytes] representing [UNCOMPRESSED Secp256k1PublicKey]', () {
+      // Arrange
+      Secp256k1PublicKey actualSecp256k1publicKey = Secp256k1PublicKey(
+        ecPublicKey: ECPublicKey(
+          CurvePoints.generatorSecp256k1,
+          ECPoint(
+            curve: Curves.secp256k1,
+            n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+            x: BigInt.parse('109809582697629541179477143463768131161650648020283737506803606109779771350309'),
+            y: BigInt.parse('93904199375389538639503047221917403320671286887529822165996195593332713512966'),
+            z: BigInt.parse('15114296647857780461657875995579731758281183768828053400819025202844531705682'),
+          ),
+        ),
+      );
+
+      // Act
+      Uint8List actualCompressedPublicKey = actualSecp256k1publicKey.uncompressed;
+
+      // Assert
+      Uint8List expectedCompressedPublicKey = base64Decode('BL+tLoQUarMHBlWt2YHvheCerhvBi3VacJya8XNUx2YjRdh4yvIJvEV4shNwcx/bJI+WUme3DGfy1SuRlBmPA4o=');
+
+      expect(actualCompressedPublicKey, expectedCompressedPublicKey);
+    });
+  });
+}


### PR DESCRIPTION
BIP-32 (Bitcoin Improvement Proposal 32), introduces a technique for hierarchical deterministic wallets in the realm of cryptocurrency. It allows for the generation of a tree-like structure of private and public keys from a single seed, enhancing security and organization in managing multiple addresses and wallets. This proposal allows users to derive an almost infinite number of distinct blockchain addresses, facilitating convenient backup, privacy, and security in cryptocurrency management.

List of changes:
- created i_bip32_private_key.dart and i_bip32_public_key.dart to define interface for keys based on different curves (e.g. secp256k1)
- created secp256k1_private_key.dart, secp256k1_public_key.dart as a first implementation of BIP-32. Secp256k1 curve is used to generate keys for various networks like Bitcoin, Ethereum and Cosmos.
- created bip32_hmac_keys.dart, containing HMAC keys for possible curves (currently only secp256k1). HMAC key is needed in the private keys derivation process.
- created a_hd_wallet.dart - an abstract object defining a result of all operations made within BIP-32 domain (e.g. keypair, derivation path, address) and legacy_hd_wallet.dart as its implementation
- created bip44_wallets_config.dart, bip49_wallets_config.dart, bip84_wallets_config.dart storing general info about wallets and their properties (like address encoder, used derivator or derivation path indexes)
- created slip44.dart containing coin indexes used in BIP-32