### PR TITLE
Feature: Public address encoders

### DIFF
--- a/lib/cryptography_utils.dart
+++ b/lib/cryptography_utils.dart
@@ -2,8 +2,11 @@ library cryptography_utils;
 
 export 'src/bip/bip.dart';
 export 'src/cdsa/cdsa.dart';
-export 'src/config/config.dart';
+export 'src/encoder/encoder.dart';
 export 'src/hash/hmac.dart';
+export 'src/hash/keccak.dart';
 export 'src/hash/pbkdf2.dart';
+export 'src/hash/ripemd160.dart';
 export 'src/slip/slip.dart';
 export 'src/utils/utils.dart';
+export 'src/wallet_config/wallet_config.dart';

--- a/lib/src/bip/bip32/bip32.dart
+++ b/lib/src/bip/bip32/bip32.dart
@@ -8,3 +8,4 @@ export 'hd_wallet/legacy_hd_wallet.dart';
 export 'keys/bip32_hmac_keys.dart';
 export 'keys/i_bip32_private_key.dart';
 export 'keys/i_bip32_public_key.dart';
+export 'keys/public_key_mode.dart';

--- a/lib/src/bip/bip32/hd_wallet/a_hd_wallet.dart
+++ b/lib/src/bip/bip32/hd_wallet/a_hd_wallet.dart
@@ -5,16 +5,18 @@ import 'package:equatable/equatable.dart';
 /// HD Wallets store private keys, public keys and addresses generated from a single master seed.
 /// https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
 abstract class AHDWallet extends Equatable {
+  final String address;
   final AWalletConfig walletConfig;
   final IBip32PrivateKey privateKey;
   final IBip32PublicKey publicKey;
 
   const AHDWallet({
+    required this.address,
     required this.walletConfig,
     required this.privateKey,
     required this.publicKey,
   });
 
   @override
-  List<Object?> get props => <Object>[walletConfig, privateKey, publicKey];
+  List<Object?> get props => <Object>[address, walletConfig, privateKey, publicKey];
 }

--- a/lib/src/bip/bip32/hd_wallet/legacy_hd_wallet.dart
+++ b/lib/src/bip/bip32/hd_wallet/legacy_hd_wallet.dart
@@ -6,6 +6,7 @@ class LegacyHDWallet extends AHDWallet {
   final LegacyDerivationPath? derivationPath;
 
   const LegacyHDWallet({
+    required super.address,
     required super.walletConfig,
     required super.privateKey,
     required super.publicKey,
@@ -23,7 +24,10 @@ class LegacyHDWallet extends AHDWallet {
     IBip32PrivateKey bip32PrivateKey = await walletConfig.derivator.derivePath(mnemonic, derivationPath);
     IBip32PublicKey bip32PublicKey = bip32PrivateKey.publicKey;
 
+    String address = walletConfig.addressEncoder.encodePublicKey(bip32PublicKey);
+
     return LegacyHDWallet(
+      address: address,
       walletConfig: walletConfig,
       privateKey: bip32PrivateKey,
       publicKey: bip32PublicKey,
@@ -32,5 +36,5 @@ class LegacyHDWallet extends AHDWallet {
   }
 
   @override
-  List<Object?> get props => <Object?>[walletConfig, privateKey, publicKey, derivationPath];
+  List<Object?> get props => <Object?>[address, walletConfig, privateKey, publicKey, derivationPath];
 }

--- a/lib/src/bip/bip32/keys/public_key_mode.dart
+++ b/lib/src/bip/bip32/keys/public_key_mode.dart
@@ -1,0 +1,4 @@
+enum PublicKeyMode {
+  compressed,
+  uncompressed,
+}

--- a/lib/src/config/config.dart
+++ b/lib/src/config/config.dart
@@ -1,5 +1,0 @@
-export 'wallets_config/bip44_wallets_config.dart';
-export 'wallets_config/bip49_wallets_config.dart';
-export 'wallets_config/bip84_wallets_config.dart';
-export 'wallets_config/objects/a_wallet_config.dart';
-export 'wallets_config/objects/legacy_wallet_config.dart';

--- a/lib/src/encoder/address_encoder/bitcoin/bitcoin_p2pkh_address_encoder.dart
+++ b/lib/src/encoder/address_encoder/bitcoin/bitcoin_p2pkh_address_encoder.dart
@@ -1,0 +1,26 @@
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// The [BitcoinP2PKHAddressEncoder] class is designed for encoding P2PKH (Pay-to-PubKey-Hash) addresses in accordance with Bitcoin.
+/// P2SH addresses utilize the RIPEMD-160 and SHA-256 hash functions to generate addresses from a script's hash.
+/// Through these methods, it produces addresses prefixed with '1 and encoded with Base58Check'.
+class BitcoinP2PKHAddressEncoder implements IBlockchainAddressEncoder<Secp256k1PublicKey> {
+  static const List<int> _networkVersionBytes = <int>[0x00];
+  final PublicKeyMode publicKeyMode;
+
+  BitcoinP2PKHAddressEncoder({
+    this.publicKeyMode = PublicKeyMode.compressed,
+  });
+
+  @override
+  String encodePublicKey(Secp256k1PublicKey publicKey) {
+    Uint8List publicKeyBytes = publicKeyMode == PublicKeyMode.compressed ? publicKey.compressed : publicKey.uncompressed;
+
+    Uint8List publicKeyFingerprint = Uint8List.fromList(sha256.convert(publicKeyBytes).bytes);
+    Uint8List publicKeyHash = Ripemd160().process(publicKeyFingerprint);
+
+    return Base58Encoder.encodeWithChecksum(Uint8List.fromList(<int>[..._networkVersionBytes, ...publicKeyHash]));
+  }
+}

--- a/lib/src/encoder/address_encoder/bitcoin/bitcoin_p2sh_address_encoder.dart
+++ b/lib/src/encoder/address_encoder/bitcoin/bitcoin_p2sh_address_encoder.dart
@@ -1,0 +1,31 @@
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// The [BitcoinP2SHAddressEncoder] class is designed for encoding P2SH (Pay-to-Script-Hash) addresses in accordance with Bitcoin.
+/// P2SH addresses utilize the RIPEMD-160 and SHA-256 hash functions to generate addresses from a script's hash.
+/// Through these methods, it produces addresses prefixed with '3 and encoded with Base58Check'.
+class BitcoinP2SHAddressEncoder implements IBlockchainAddressEncoder<Secp256k1PublicKey> {
+  static const List<int> _networkVersionBytes = <int>[0x05];
+  static const List<int> _scriptBytes = <int>[0x00, 0x14];
+
+  @override
+  String encodePublicKey(Secp256k1PublicKey publicKey) {
+    /// Generate the script signature from the public key.
+    List<int> scriptSignatureBytes = _addScriptSignature(publicKey);
+
+    return Base58Encoder.encodeWithChecksum(Uint8List.fromList(<int>[..._networkVersionBytes, ...scriptSignatureBytes]));
+  }
+
+  List<int> _addScriptSignature(Secp256k1PublicKey publicKey) {
+    Uint8List publicKeyFingerprint = Uint8List.fromList(sha256.convert(publicKey.compressed).bytes);
+    Uint8List publicKeyHash = Ripemd160().process(publicKeyFingerprint);
+
+    Uint8List signatureBytes = Uint8List.fromList(<int>[..._scriptBytes, ...publicKeyHash]);
+    Uint8List signatureFingerprint = Uint8List.fromList(sha256.convert(signatureBytes).bytes);
+    Uint8List signatureHash = Ripemd160().process(signatureFingerprint);
+
+    return signatureHash;
+  }
+}

--- a/lib/src/encoder/address_encoder/bitcoin/bitcoin_p2wpkh_address_encoder.dart
+++ b/lib/src/encoder/address_encoder/bitcoin/bitcoin_p2wpkh_address_encoder.dart
@@ -1,0 +1,25 @@
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// The [BitcoinP2WPKHAddressEncoder] class is designed for encoding P2WPKH (Pay-to-Witness-Public-Key-Hash) addresses in accordance with Bitcoin.
+/// P2SH addresses utilize the RIPEMD-160 and SHA-256 hash functions to generate addresses from a script's hash.
+/// P2WPKH addresses are encoded using the Bech32 (Segwit) algorithm, which is specified in BIP-0173 and BIP-0350:
+/// https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+/// https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki
+class BitcoinP2WPKHAddressEncoder implements IBlockchainAddressEncoder<Secp256k1PublicKey> {
+  static const int _witnessVersion = 0;
+
+  final String hrp;
+
+  BitcoinP2WPKHAddressEncoder({required this.hrp});
+
+  @override
+  String encodePublicKey(Secp256k1PublicKey publicKey) {
+    Uint8List publicKeyFingerprint = Uint8List.fromList(sha256.convert(publicKey.compressed).bytes);
+    Uint8List publicKeyHash = Ripemd160().process(publicKeyFingerprint);
+
+    return SegwitBech32Encoder.encode(hrp, _witnessVersion, publicKeyHash);
+  }
+}

--- a/lib/src/encoder/address_encoder/cosmos_address_encoder.dart
+++ b/lib/src/encoder/address_encoder/cosmos_address_encoder.dart
@@ -1,0 +1,22 @@
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// The [CosmosAddressEncoder] class is designed for encoding addresses in accordance with the Cosmos network.
+/// Cosmos addresses are encoded using the Bech32 algorithm, which is specified in BIP-0173 and BIP-0350:
+/// https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+/// https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki
+class CosmosAddressEncoder implements IBlockchainAddressEncoder<Secp256k1PublicKey> {
+  final String hrp;
+
+  CosmosAddressEncoder({required this.hrp});
+
+  @override
+  String encodePublicKey(Secp256k1PublicKey publicKey) {
+    Uint8List publicKeyFingerprint = Uint8List.fromList(sha256.convert(publicKey.compressed).bytes);
+    Uint8List publicKeyHash = Ripemd160().process(publicKeyFingerprint);
+
+    return Bech32Encoder.encode(hrp, publicKeyHash);
+  }
+}

--- a/lib/src/encoder/address_encoder/ethereum_address_encoder.dart
+++ b/lib/src/encoder/address_encoder/ethereum_address_encoder.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// The [EthereumAddressEncoder] class is designed for encoding addresses in accordance with the Ethereum network.
+/// Ethereum uses the Keccak-256 hash function to generate addresses from public keys, resulting in 40 hexadecimal characters prefixed with "0x".
+/// https://info.etherscan.com/what-is-an-ethereum-address/
+class EthereumAddressEncoder implements IBlockchainAddressEncoder<Secp256k1PublicKey> {
+  static const int _startByte = 24;
+
+  final bool skipChecksumBool;
+
+  EthereumAddressEncoder({
+    this.skipChecksumBool = false,
+  });
+
+  @override
+  String encodePublicKey(Secp256k1PublicKey publicKey) {
+    Uint8List keccakHash = Keccak(256).process(publicKey.uncompressed.sublist(1));
+    String keccakHex = HexEncoder.encode(keccakHash, lowercaseBool: true);
+
+    String address = keccakHex.substring(_startByte);
+    if (skipChecksumBool) {
+      return address;
+    }
+    return '0x${_wrapWithChecksum(address)}';
+  }
+
+  static String _wrapWithChecksum(String address) {
+    Uint8List addressBytes = utf8.encode(address.toLowerCase());
+    Uint8List checksumBytes = Keccak(256).process(addressBytes);
+    String checksumHex = HexEncoder.encode(checksumBytes, lowercaseBool: true);
+
+    List<String> addressWithChecksum = address.split('').asMap().entries.map((MapEntry<int, String> entry) {
+      int index = entry.key;
+      String char = entry.value;
+      int charChecksumHex = int.parse(checksumHex[index], radix: 16);
+      return charChecksumHex >= 8 ? char.toUpperCase() : char.toLowerCase();
+    }).toList();
+
+    return addressWithChecksum.join();
+  }
+}

--- a/lib/src/encoder/address_encoder/i_blockchain_address_encoder.dart
+++ b/lib/src/encoder/address_encoder/i_blockchain_address_encoder.dart
@@ -1,0 +1,6 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// The [IBlockchainAddressEncoder] interface is designed for encode addresses in accordance with the specific blockchain network.
+abstract interface class IBlockchainAddressEncoder<T extends IBip32PublicKey> {
+  String encodePublicKey(T publicKey);
+}

--- a/lib/src/encoder/encoder.dart
+++ b/lib/src/encoder/encoder.dart
@@ -1,0 +1,10 @@
+export 'address_encoder/bitcoin/bitcoin_p2pkh_address_encoder.dart';
+export 'address_encoder/bitcoin/bitcoin_p2sh_address_encoder.dart';
+export 'address_encoder/bitcoin/bitcoin_p2wpkh_address_encoder.dart';
+export 'address_encoder/cosmos_address_encoder.dart';
+export 'address_encoder/ethereum_address_encoder.dart';
+export 'address_encoder/i_blockchain_address_encoder.dart';
+export 'generic_encoder/base/base58_encoder.dart';
+export 'generic_encoder/bech32/bech32_encoder.dart';
+export 'generic_encoder/bech32/segwit_bech32_encoder.dart';
+export 'generic_encoder/hex_encoder.dart';

--- a/lib/src/encoder/generic_encoder/base/base58_encoder.dart
+++ b/lib/src/encoder/generic_encoder/base/base58_encoder.dart
@@ -1,0 +1,104 @@
+// Class was shaped by the influence of several key sources including:
+// "blockchain_utils" - Copyright (c) 2010 Mohsen
+// https://github.com/mrtnetwork/blockchain_utils/.
+//
+// BSD 3-Clause License
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// The [Base58Encoder] class is designed for encoding data using the Base58 encoding scheme.
+class Base58Encoder {
+  static const String _bitcoinCheckAlphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+  static String encodeWithChecksum(Uint8List dataBytes) {
+    List<int> checksum = _computeChecksum(dataBytes);
+    List<int> dataWithChecksum = List<int>.from(<int>[...dataBytes, ...checksum]);
+    return encode(Uint8List.fromList(dataWithChecksum));
+  }
+
+  static String encode(Uint8List dataBytes) {
+    String alphabet = _bitcoinCheckAlphabet;
+
+    BigInt value = BigIntUtils.decode(dataBytes);
+    String enc = '';
+    while (value > BigInt.zero) {
+      BigInt dividedValue = value ~/ BigInt.from(58);
+      BigInt modulatedValue = value % BigInt.from(58);
+
+      value = dividedValue;
+      enc = alphabet[modulatedValue.toInt()] + enc;
+    }
+
+    int zero = 0;
+    for (int byte in dataBytes) {
+      if (byte == 0) {
+        zero++;
+      } else {
+        break;
+      }
+    }
+    final int leadingZeros = dataBytes.length - (dataBytes.length - zero);
+
+    return (alphabet[0] * leadingZeros) + enc;
+  }
+
+  static Uint8List decode(String data) {
+    String alphabet = _bitcoinCheckAlphabet;
+    BigInt val = BigInt.zero;
+
+    for (int i = 0; i < data.length; i++) {
+      String c = data[data.length - 1 - i];
+      int charIndex = alphabet.indexOf(c);
+      if (charIndex == -1) {
+        throw const FormatException('Invalid character in Base58 string');
+      }
+      val += BigInt.from(charIndex) * BigInt.from(58).pow(i);
+    }
+
+    Uint8List bytes = BigIntUtils.changeToBytes(val);
+
+    int padLen = 0;
+    for (int i = 0; i < data.length; i++) {
+      if (data[i] == alphabet[0]) {
+        padLen++;
+      } else {
+        break;
+      }
+    }
+
+    return Uint8List.fromList(<int>[...List<int>.filled(padLen, 0), ...bytes]);
+  }
+
+  static List<int> _computeChecksum(Uint8List dataBytes) {
+    Uint8List doubleSha256Digest = Uint8List.fromList(sha256.convert(sha256.convert(dataBytes).bytes).bytes);
+    return doubleSha256Digest.sublist(0, 4);
+  }
+}

--- a/lib/src/encoder/generic_encoder/bech32/bech32_encoder.dart
+++ b/lib/src/encoder/generic_encoder/bech32/bech32_encoder.dart
@@ -1,0 +1,51 @@
+import 'dart:typed_data';
+
+import 'package:bech32/bech32.dart';
+
+/// The [Bech32Encoder] class is designed for encoding data using the Bech32 encoding scheme.
+/// The specification for Bech32 encoding can be found in BIP-0173 and BIP-0350:
+/// https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+/// https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki
+class Bech32Encoder {
+  static String encode(String hrp, List<int> data) {
+    Uint8List convertedData = _convertBits(data, 8, 5);
+    // TODO(dominik): Implement custom BECH32 encoder
+    return bech32.encode(Bech32(hrp, convertedData));
+  }
+
+  static Uint8List _convertBits(
+    List<int> data,
+    int startBitIndex,
+    int endBitIndex, {
+    bool padBool = true,
+  }) {
+    int acc = 0;
+    int bits = 0;
+    List<int> result = <int>[];
+    int maxV = (1 << endBitIndex) - 1;
+
+    for (int v in data) {
+      if (v < 0 || (v >> startBitIndex) != 0) {
+        throw Exception('Got address byte smaller than zero or greater than 2^startBitIndex');
+      }
+      acc = (acc << startBitIndex) | v;
+      bits += startBitIndex;
+      while (bits >= endBitIndex) {
+        bits -= endBitIndex;
+        result.add((acc >> bits) & maxV);
+      }
+    }
+
+    if (padBool) {
+      if (bits > 0) {
+        result.add((acc << (endBitIndex - bits)) & maxV);
+      }
+    } else if (bits >= startBitIndex) {
+      throw Exception('Illegal zero padding');
+    } else if (((acc << (endBitIndex - bits)) & maxV) != 0) {
+      throw Exception('Non zero');
+    }
+
+    return Uint8List.fromList(result);
+  }
+}

--- a/lib/src/encoder/generic_encoder/bech32/segwit_bech32_encoder.dart
+++ b/lib/src/encoder/generic_encoder/bech32/segwit_bech32_encoder.dart
@@ -1,0 +1,12 @@
+import 'package:bech32/bech32.dart';
+
+/// The [SegwitBech32Encoder] class is designed for encoding Segregated Witness (SegWit) addresses using the Bech32 encoding scheme,
+/// as outlined in BIP-0173 and further refined for SegWit in BIP-0174:
+/// https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+/// https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki
+class SegwitBech32Encoder {
+  static String encode(String hrp, int witnessVersion, List<int> witnessProgram) {
+    // TODO(dominik): Implement custom Segwit encoder
+    return SegwitEncoder().convert(Segwit(hrp, witnessVersion, witnessProgram));
+  }
+}

--- a/lib/src/encoder/generic_encoder/hex_encoder.dart
+++ b/lib/src/encoder/generic_encoder/hex_encoder.dart
@@ -1,0 +1,46 @@
+import 'dart:typed_data';
+
+/// The [HexEncoder] class is designed for encoding and decoding data using the hexadecimal encoding scheme.
+class HexEncoder {
+  /// Encodes the given [data] as a hexadecimal string.
+  static String encode(List<int> data, {bool lowercaseBool = true}) {
+    List<String> hexString = data.map((int e) => e.toRadixString(16).padLeft(2, '0')).toList();
+    String hexData = hexString.join();
+
+    if (lowercaseBool) {
+      return hexData.toLowerCase();
+    } else {
+      return hexData.toUpperCase();
+    }
+  }
+
+  /// Decodes the given [hex] string into a list of bytes.
+  static Uint8List decode(String hex) {
+    String tmpHex = hex.toLowerCase();
+    if (hex.startsWith('0x')) {
+      tmpHex = hex.substring(2);
+    }
+    List<String> hexString = tmpHex.split('');
+    List<String> hexPairs = <String>[];
+
+    for (int i = 0; i < hexString.length; i += 2) {
+      String hexPair = hexString[i] + hexString[i + 1];
+      hexPairs.add(hexPair);
+    }
+
+    List<int> hexPairsInt = hexPairs.map((String e) => int.parse(e, radix: 16)).toList();
+    Uint8List hexPairsUint8List = Uint8List.fromList(hexPairsInt);
+
+    return hexPairsUint8List;
+  }
+
+  /// Returns whether the given [hex] string is a valid hexadecimal string.
+  static bool isHex(String hex) {
+    try {
+      decode(hex);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+}

--- a/lib/src/hash/keccak.dart
+++ b/lib/src/hash/keccak.dart
@@ -1,0 +1,16 @@
+import 'dart:typed_data';
+
+import 'package:pointycastle/digests/keccak.dart';
+
+/// [Keccak] is an implementation of Keccak algorithm which is a secure hash
+/// function that creates fixed-size outputs from variable-length inputs.
+class Keccak {
+  final int digestSize;
+
+  Keccak(this.digestSize);
+
+  Uint8List process(Uint8List data) {
+    // TODO(dominik): Implement custom version of Keccak hashing.
+    return KeccakDigest(digestSize).process(data);
+  }
+}

--- a/lib/src/hash/ripemd160.dart
+++ b/lib/src/hash/ripemd160.dart
@@ -1,0 +1,12 @@
+import 'dart:typed_data';
+
+import 'package:pointycastle/digests/ripemd160.dart';
+
+/// [Ripemd160] is an implementation of RIPEMD-160  algorithm which is a secure hash function
+/// producing a 160-bit output, used for secure data processing and digital signatures.
+class Ripemd160 {
+  Uint8List process(Uint8List data) {
+    // TODO(dominik): Implement custom version of RIPEMD16 hashing.
+    return RIPEMD160Digest().process(data);
+  }
+}

--- a/lib/src/slip/slip.dart
+++ b/lib/src/slip/slip.dart
@@ -1,1 +1,2 @@
+export 'slip173.dart';
 export 'slip44.dart';

--- a/lib/src/slip/slip173.dart
+++ b/lib/src/slip/slip173.dart
@@ -1,0 +1,6 @@
+/// Implementation of SLIP-0173, which defines the BIP-44 coin indexes
+class Slip173 {
+  static const String bitcoin = 'bc';
+  static const String cosmos = 'cosmos';
+  static const String kira = 'kira';
+}

--- a/lib/src/wallet_config/bip44_wallets_config.dart
+++ b/lib/src/wallet_config/bip44_wallets_config.dart
@@ -2,33 +2,38 @@ import 'package:cryptography_utils/cryptography_utils.dart';
 
 /// [Bip44WalletsConfig] class provides configurations for creating wallets adhering to BIP-44 standards.
 /// Configurations include:
+///   - `addressEncoder`: Algorithm used for address encoding
 ///   - `derivator`: Algorithm used for key derivation
 ///   - `coinIndex`: Index of the coin as per the SLIP44 standard
 ///   - `curveType`: Type of the elliptic curve used for key generation
 ///   - `purpose`: Type of the BIP proposal
 class Bip44WalletsConfig {
   static LegacyWalletConfig bitcoin = LegacyWalletConfig(
+    addressEncoder: BitcoinP2PKHAddressEncoder(),
     derivator: Secp256k1Derivator(),
     coinIndex: Slip44.bitcoin,
     curveType: CurveType.secp256k1,
     purpose: BipProposalType.bip44,
   );
 
-  static LegacyWalletConfig ethereum = LegacyWalletConfig(
-    derivator: Secp256k1Derivator(),
-    coinIndex: Slip44.ethereum,
-    curveType: CurveType.secp256k1,
-    purpose: BipProposalType.bip44,
-  );
-
   static LegacyWalletConfig cosmos = LegacyWalletConfig(
+    addressEncoder: CosmosAddressEncoder(hrp: Slip173.cosmos),
     derivator: Secp256k1Derivator(),
     coinIndex: Slip44.cosmos,
     curveType: CurveType.secp256k1,
     purpose: BipProposalType.bip44,
   );
 
+  static LegacyWalletConfig ethereum = LegacyWalletConfig(
+    addressEncoder: EthereumAddressEncoder(),
+    derivator: Secp256k1Derivator(),
+    coinIndex: Slip44.ethereum,
+    curveType: CurveType.secp256k1,
+    purpose: BipProposalType.bip44,
+  );
+
   static LegacyWalletConfig kira = LegacyWalletConfig(
+    addressEncoder: CosmosAddressEncoder(hrp: Slip173.kira),
     derivator: Secp256k1Derivator(),
     coinIndex: Slip44.kira,
     curveType: CurveType.secp256k1,

--- a/lib/src/wallet_config/bip49_wallets_config.dart
+++ b/lib/src/wallet_config/bip49_wallets_config.dart
@@ -2,12 +2,14 @@ import 'package:cryptography_utils/cryptography_utils.dart';
 
 /// [Bip49WalletsConfig] class provides configurations for creating wallets adhering to BIP-49 standards.
 /// Configurations include:
+///   - `addressEncoder`: Algorithm used for address encoding
 ///   - `derivator`: Algorithm used for key derivation
 ///   - `coinIndex`: Index of the coin as per the SLIP44 standard
 ///   - `curveType`: Type of the elliptic curve used for key generation
 ///   - `purpose`: Type of the BIP proposal
 class Bip49WalletsConfig {
   static LegacyWalletConfig bitcoin = LegacyWalletConfig(
+    addressEncoder: BitcoinP2SHAddressEncoder(),
     derivator: Secp256k1Derivator(),
     coinIndex: Slip44.bitcoin,
     curveType: CurveType.secp256k1,

--- a/lib/src/wallet_config/bip84_wallets_config.dart
+++ b/lib/src/wallet_config/bip84_wallets_config.dart
@@ -2,12 +2,14 @@ import 'package:cryptography_utils/cryptography_utils.dart';
 
 /// [Bip84WalletsConfig] class provides configurations for creating wallets adhering to BIP-84 standards.
 /// Configurations include:
+///   - `addressEncoder`: Algorithm used for address encoding
 ///   - `derivator`: Algorithm used for key derivation
 ///   - `coinIndex`: Index of the coin as per the SLIP44 standard
 ///   - `curveType`: Type of the elliptic curve used for key generation
 ///   - `purpose`: Type of the BIP proposal
 class Bip84WalletsConfig {
   static LegacyWalletConfig bitcoin = LegacyWalletConfig(
+    addressEncoder: BitcoinP2WPKHAddressEncoder(hrp: Slip173.bitcoin),
     derivator: Secp256k1Derivator(),
     coinIndex: Slip44.bitcoin,
     curveType: CurveType.secp256k1,

--- a/lib/src/wallet_config/config_types/a_wallet_config.dart
+++ b/lib/src/wallet_config/config_types/a_wallet_config.dart
@@ -2,12 +2,14 @@ import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:equatable/equatable.dart';
 
 abstract class AWalletConfig extends Equatable {
+  final IBlockchainAddressEncoder<dynamic> addressEncoder;
   final IDerivator derivator;
 
   const AWalletConfig({
+    required this.addressEncoder,
     required this.derivator,
   });
 
   @override
-  List<Object?> get props => <Object>[derivator];
+  List<Object?> get props => <Object>[addressEncoder, derivator];
 }

--- a/lib/src/wallet_config/config_types/legacy_wallet_config.dart
+++ b/lib/src/wallet_config/config_types/legacy_wallet_config.dart
@@ -7,6 +7,7 @@ class LegacyWalletConfig extends AWalletConfig {
 
   const LegacyWalletConfig({
     required ILegacyDerivator derivator,
+    required super.addressEncoder,
     required this.coinIndex,
     required this.curveType,
     required this.purpose,

--- a/lib/src/wallet_config/wallet_config.dart
+++ b/lib/src/wallet_config/wallet_config.dart
@@ -1,0 +1,5 @@
+export 'bip44_wallets_config.dart';
+export 'bip49_wallets_config.dart';
+export 'bip84_wallets_config.dart';
+export 'config_types//a_wallet_config.dart';
+export 'config_types/legacy_wallet_config.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cryptography_utils
 description: "Cryptography utils"
-version: 0.0.5
+version: 0.0.6
 
 environment:
   sdk: ">=3.2.2"
@@ -17,6 +17,14 @@ dependencies:
   # Implementations of SHA, MD5, and HMAC cryptographic functions.
   # https://pub.dev/packages/crypto
   crypto: ^3.0.3
+
+  # Library implementing Bitcoins BIP173 (Bech32 encoding) specification in a Flutter friendly fashion.
+  # https://pub.dev/packages/bech32
+  bech32: ^0.2.2
+
+  # A Dart library implementing cryptographic algorithms and primitives, modeled on the BouncyCastle library.
+  # https://pub.dev/packages/pointycastle
+  pointycastle: ^3.7.4
 
 dev_dependencies:
   flutter_test:

--- a/test/bip/bip32/hd_wallet/legacy_hd_wallet_test.dart
+++ b/test/bip/bip32/hd_wallet/legacy_hd_wallet_test.dart
@@ -8,114 +8,6 @@ void main() {
       'require point property company tongue busy bench burden caution gadget knee glance thought bulk assist month cereal report quarter tool section often require shield');
 
   group('Tests of LegacyHDWallet.fromMnemonic()', () {
-    test('Should [return LegacyHDWallet] from given mnemonic (BIP44-Kira)', () async {
-      // Act
-      LegacyHDWallet actualKiraWallet = await LegacyHDWallet.fromMnemonic(
-        mnemonic: mnemonic,
-        walletConfig: Bip44WalletsConfig.kira,
-        derivationPathString: "m/44'/118'/0'/0/0",
-      );
-
-      // Assert
-      LegacyHDWallet expectedKiraWallet = LegacyHDWallet(
-        walletConfig: Bip44WalletsConfig.kira,
-        privateKey: Secp256k1PrivateKey(
-          chainCode: base64Decode('atgf2JWMxW014Hby5ccSn5NlRKQvIV2jvsdtcN3Eb8I='),
-          ecPrivateKey: ECPrivateKey(
-            CurvePoints.generatorSecp256k1,
-            BigInt.parse('25933686250415448129536663355227060923413846494721047098076326567395973050293'),
-          ),
-        ),
-        publicKey: Secp256k1PublicKey(
-          ecPublicKey: ECPublicKey(
-            CurvePoints.generatorSecp256k1,
-            ECPoint(
-              curve: Curves.secp256k1,
-              n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
-              x: BigInt.parse('103541830980023606809613093633067363502594290705821036222890728111110906420509'),
-              y: BigInt.parse('75808906644622006047938879719654783679105512040910575915102508326553703647166'),
-              z: BigInt.parse('3190226348536498292494465017020441737630476122313049345633869118655223224149'),
-            ),
-          ),
-        ),
-        derivationPath: LegacyDerivationPath.parse("m/44'/118'/0'/0/0"),
-      );
-
-      expect(actualKiraWallet, expectedKiraWallet);
-    });
-
-    test('Should [return LegacyHDWallet] from given mnemonic (BIP44-Cosmos)', () async {
-      // Act
-      LegacyHDWallet actualCosmosWallet = await LegacyHDWallet.fromMnemonic(
-        mnemonic: mnemonic,
-        walletConfig: Bip44WalletsConfig.cosmos,
-        derivationPathString: "m/44'/118'/0'/0/0",
-      );
-
-      // Assert
-      LegacyHDWallet expectedCosmosWallet = LegacyHDWallet(
-        walletConfig: Bip44WalletsConfig.cosmos,
-        privateKey: Secp256k1PrivateKey(
-          chainCode: base64Decode('atgf2JWMxW014Hby5ccSn5NlRKQvIV2jvsdtcN3Eb8I='),
-          ecPrivateKey: ECPrivateKey(
-            CurvePoints.generatorSecp256k1,
-            BigInt.parse('25933686250415448129536663355227060923413846494721047098076326567395973050293'),
-          ),
-        ),
-        publicKey: Secp256k1PublicKey(
-          ecPublicKey: ECPublicKey(
-            CurvePoints.generatorSecp256k1,
-            ECPoint(
-              curve: Curves.secp256k1,
-              n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
-              x: BigInt.parse('103541830980023606809613093633067363502594290705821036222890728111110906420509'),
-              y: BigInt.parse('75808906644622006047938879719654783679105512040910575915102508326553703647166'),
-              z: BigInt.parse('3190226348536498292494465017020441737630476122313049345633869118655223224149'),
-            ),
-          ),
-        ),
-        derivationPath: LegacyDerivationPath.parse("m/44'/118'/0'/0/0"),
-      );
-
-      expect(actualCosmosWallet, expectedCosmosWallet);
-    });
-
-    test('Should [return LegacyHDWallet] from given mnemonic (BIP44-Ethereum)', () async {
-      // Act
-      LegacyHDWallet actualEthereumWallet = await LegacyHDWallet.fromMnemonic(
-        mnemonic: mnemonic,
-        walletConfig: Bip44WalletsConfig.ethereum,
-        derivationPathString: "m/44'/60'/0'/0/0",
-      );
-
-      // Assert
-      LegacyHDWallet expectedEthereumWallet = LegacyHDWallet(
-        walletConfig: Bip44WalletsConfig.ethereum,
-        privateKey: Secp256k1PrivateKey(
-          chainCode: base64Decode('YsN74zJ6p9/kjsFCM5UUBq470XR3CEssHXyawdn7xBw='),
-          ecPrivateKey: ECPrivateKey(
-            CurvePoints.generatorSecp256k1,
-            BigInt.parse('91850346642365090382529827989594437164777469345439968194889143349494450093883'),
-          ),
-        ),
-        publicKey: Secp256k1PublicKey(
-          ecPublicKey: ECPublicKey(
-            CurvePoints.generatorSecp256k1,
-            ECPoint(
-              curve: Curves.secp256k1,
-              n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
-              x: BigInt.parse('49844093485842753019501723164709087800134847594852664670182601545797061237061'),
-              y: BigInt.parse('102584019795063234624860865414832132871049165551248963828805190591824528686504'),
-              z: BigInt.parse('33112508886275853310422687256511308836721055527980470378416551104097868981749'),
-            ),
-          ),
-        ),
-        derivationPath: LegacyDerivationPath.parse("m/44'/60'/0'/0/0"),
-      );
-
-      expect(actualEthereumWallet, expectedEthereumWallet);
-    });
-
     test('Should [return LegacyHDWallet] from given mnemonic (BIP44-Bitcoin)', () async {
       // Act
       LegacyHDWallet actualBitcoinBip44Wallet = await LegacyHDWallet.fromMnemonic(
@@ -126,6 +18,7 @@ void main() {
 
       // Assert
       LegacyHDWallet expectedBitcoinBip44Wallet = LegacyHDWallet(
+        address: '12CUuS1w48dmLqug3sQeZGXhM6ziyLdDFR',
         walletConfig: Bip44WalletsConfig.bitcoin,
         privateKey: Secp256k1PrivateKey(
           chainCode: base64Decode('rEcUq915xZMcSVN9UIfhWIf7c+cb9fURwnXSJ59fbhs='),
@@ -162,6 +55,7 @@ void main() {
 
       // Assert
       LegacyHDWallet expectedBitcoinBip49Wallet = LegacyHDWallet(
+        address: '38BaaMYeUR32tptWPcfLiuZwdkq1iHy7mW',
         walletConfig: Bip49WalletsConfig.bitcoin,
         privateKey: Secp256k1PrivateKey(
           chainCode: base64Decode('dD+m4pyYe3edlY9ZDNDpe370dwMmGNF2ihkMDXjYSpY='),
@@ -198,6 +92,7 @@ void main() {
 
       // Assert
       LegacyHDWallet expectedBitcoinBip84Wallet = LegacyHDWallet(
+        address: 'bc1quxjugvagpv4kz5hdkh7x0qklarw5akdk2sg0wp',
         walletConfig: Bip84WalletsConfig.bitcoin,
         privateKey: Secp256k1PrivateKey(
           chainCode: base64Decode('HmhuNs2LO3+/SpMIb4FCOCRlS5Ym+ACIprpAAmG4zMI='),
@@ -222,6 +117,117 @@ void main() {
       );
 
       expect(actualBitcoinBip84Wallet, expectedBitcoinBip84Wallet);
+    });
+
+    test('Should [return LegacyHDWallet] from given mnemonic (BIP44-Cosmos)', () async {
+      // Act
+      LegacyHDWallet actualCosmosWallet = await LegacyHDWallet.fromMnemonic(
+        mnemonic: mnemonic,
+        walletConfig: Bip44WalletsConfig.cosmos,
+        derivationPathString: "m/44'/118'/0'/0/0",
+      );
+
+      // Assert
+      LegacyHDWallet expectedCosmosWallet = LegacyHDWallet(
+        address: 'cosmos143q8vxpvuykt9pq50e6hng9s38vmy844rgut0t',
+        walletConfig: Bip44WalletsConfig.cosmos,
+        privateKey: Secp256k1PrivateKey(
+          chainCode: base64Decode('atgf2JWMxW014Hby5ccSn5NlRKQvIV2jvsdtcN3Eb8I='),
+          ecPrivateKey: ECPrivateKey(
+            CurvePoints.generatorSecp256k1,
+            BigInt.parse('25933686250415448129536663355227060923413846494721047098076326567395973050293'),
+          ),
+        ),
+        publicKey: Secp256k1PublicKey(
+          ecPublicKey: ECPublicKey(
+            CurvePoints.generatorSecp256k1,
+            ECPoint(
+              curve: Curves.secp256k1,
+              n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+              x: BigInt.parse('103541830980023606809613093633067363502594290705821036222890728111110906420509'),
+              y: BigInt.parse('75808906644622006047938879719654783679105512040910575915102508326553703647166'),
+              z: BigInt.parse('3190226348536498292494465017020441737630476122313049345633869118655223224149'),
+            ),
+          ),
+        ),
+        derivationPath: LegacyDerivationPath.parse("m/44'/118'/0'/0/0"),
+      );
+
+      expect(actualCosmosWallet, expectedCosmosWallet);
+    });
+
+    test('Should [return LegacyHDWallet] from given mnemonic (BIP44-Ethereum)', () async {
+      // Act
+      LegacyHDWallet actualEthereumWallet = await LegacyHDWallet.fromMnemonic(
+        mnemonic: mnemonic,
+        walletConfig: Bip44WalletsConfig.ethereum,
+        derivationPathString: "m/44'/60'/0'/0/0",
+      );
+
+      // Assert
+      LegacyHDWallet expectedEthereumWallet = LegacyHDWallet(
+        address: '0x50e10257924889818aA729c6EDfa02524b32Edb9',
+        walletConfig: Bip44WalletsConfig.ethereum,
+        privateKey: Secp256k1PrivateKey(
+          chainCode: base64Decode('YsN74zJ6p9/kjsFCM5UUBq470XR3CEssHXyawdn7xBw='),
+          ecPrivateKey: ECPrivateKey(
+            CurvePoints.generatorSecp256k1,
+            BigInt.parse('91850346642365090382529827989594437164777469345439968194889143349494450093883'),
+          ),
+        ),
+        publicKey: Secp256k1PublicKey(
+          ecPublicKey: ECPublicKey(
+            CurvePoints.generatorSecp256k1,
+            ECPoint(
+              curve: Curves.secp256k1,
+              n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+              x: BigInt.parse('49844093485842753019501723164709087800134847594852664670182601545797061237061'),
+              y: BigInt.parse('102584019795063234624860865414832132871049165551248963828805190591824528686504'),
+              z: BigInt.parse('33112508886275853310422687256511308836721055527980470378416551104097868981749'),
+            ),
+          ),
+        ),
+        derivationPath: LegacyDerivationPath.parse("m/44'/60'/0'/0/0"),
+      );
+
+      expect(actualEthereumWallet, expectedEthereumWallet);
+    });
+
+    test('Should [return LegacyHDWallet] from given mnemonic (BIP44-Kira)', () async {
+      // Act
+      LegacyHDWallet actualKiraWallet = await LegacyHDWallet.fromMnemonic(
+        mnemonic: mnemonic,
+        walletConfig: Bip44WalletsConfig.kira,
+        derivationPathString: "m/44'/118'/0'/0/0",
+      );
+
+      // Assert
+      LegacyHDWallet expectedKiraWallet = LegacyHDWallet(
+        address: 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+        walletConfig: Bip44WalletsConfig.kira,
+        privateKey: Secp256k1PrivateKey(
+          chainCode: base64Decode('atgf2JWMxW014Hby5ccSn5NlRKQvIV2jvsdtcN3Eb8I='),
+          ecPrivateKey: ECPrivateKey(
+            CurvePoints.generatorSecp256k1,
+            BigInt.parse('25933686250415448129536663355227060923413846494721047098076326567395973050293'),
+          ),
+        ),
+        publicKey: Secp256k1PublicKey(
+          ecPublicKey: ECPublicKey(
+            CurvePoints.generatorSecp256k1,
+            ECPoint(
+              curve: Curves.secp256k1,
+              n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+              x: BigInt.parse('103541830980023606809613093633067363502594290705821036222890728111110906420509'),
+              y: BigInt.parse('75808906644622006047938879719654783679105512040910575915102508326553703647166'),
+              z: BigInt.parse('3190226348536498292494465017020441737630476122313049345633869118655223224149'),
+            ),
+          ),
+        ),
+        derivationPath: LegacyDerivationPath.parse("m/44'/118'/0'/0/0"),
+      );
+
+      expect(actualKiraWallet, expectedKiraWallet);
     });
   });
 }

--- a/test/encoder/address_encoder/bitcoin/bitcoin_p2pkh_address_encoder_test.dart
+++ b/test/encoder/address_encoder/bitcoin/bitcoin_p2pkh_address_encoder_test.dart
@@ -1,0 +1,42 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  ECPoint actualPointQ = ECPoint(
+    x: BigInt.parse('38336877429777144060267786813855742566762755003810222330370030177500553175552'),
+    y: BigInt.parse('43563831752869961512099662435070760564842488811079803779798870455459619618648'),
+    z: BigInt.parse('84221606303351351252384011276733806130312533127115701665238461934963837834470'),
+    n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+    curve: Curves.secp256k1,
+  );
+
+  Secp256k1PublicKey actualPublicKey = Secp256k1PublicKey(ecPublicKey: ECPublicKey(CurvePoints.generatorSecp256k1, actualPointQ));
+
+  group('Tests of BitcoinP2PKHAddressEncoder.encodePublicKey()', () {
+    test('Should [return Bitcoin P2PKH address] for given public key (public key COMPRESSED)', () {
+      // Arrange
+      BitcoinP2PKHAddressEncoder actualBitcoinP2PKHAddressEncoder = BitcoinP2PKHAddressEncoder(publicKeyMode: PublicKeyMode.compressed);
+
+      // Act
+      String actualAddress = actualBitcoinP2PKHAddressEncoder.encodePublicKey(actualPublicKey);
+
+      // Assert
+      String expectedAddress = '12CUuS1w48dmLqug3sQeZGXhM6ziyLdDFR';
+
+      expect(actualAddress, expectedAddress);
+    });
+
+    test('Should [return Bitcoin P2PKH address] for given public key (public key UNCOMPRESSED)', () {
+      // Arrange
+      BitcoinP2PKHAddressEncoder actualBitcoinP2PKHAddressEncoder = BitcoinP2PKHAddressEncoder(publicKeyMode: PublicKeyMode.uncompressed);
+
+      // Act
+      String actualAddress = actualBitcoinP2PKHAddressEncoder.encodePublicKey(actualPublicKey);
+
+      // Assert
+      String expectedAddress = '1PkHDRGVzHNc3dSnBEZ8MzULiyTKEibk7c';
+
+      expect(actualAddress, expectedAddress);
+    });
+  });
+}

--- a/test/encoder/address_encoder/bitcoin/bitcoin_p2sh_address_encoder_test.dart
+++ b/test/encoder/address_encoder/bitcoin/bitcoin_p2sh_address_encoder_test.dart
@@ -1,0 +1,29 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  ECPoint actualPointQ = ECPoint(
+    x: BigInt.parse('45598833024007063412331531275003851810927383922680420932075021036000176892257'),
+    y: BigInt.parse('52075805451846365275495005964097842681620553159632658097877797800509943385562'),
+    z: BigInt.parse('11902898874332229604673834019199903475888972972060602920606280067238874780442'),
+    n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+    curve: Curves.secp256k1,
+  );
+
+  Secp256k1PublicKey actualPublicKey = Secp256k1PublicKey(ecPublicKey: ECPublicKey(CurvePoints.generatorSecp256k1, actualPointQ));
+
+  group('Tests of BitcoinP2SHAddressEncoder.encodePublicKey()', () {
+    test('Should [return Bitcoin P2SH address] for given public key', () {
+      // Arrange
+      BitcoinP2SHAddressEncoder actualBitcoinP2SHAddressEncoder = BitcoinP2SHAddressEncoder();
+
+      // Act
+      String actualAddress = actualBitcoinP2SHAddressEncoder.encodePublicKey(actualPublicKey);
+
+      // Assert
+      String expectedAddress = '38BaaMYeUR32tptWPcfLiuZwdkq1iHy7mW';
+
+      expect(actualAddress, expectedAddress);
+    });
+  });
+}

--- a/test/encoder/address_encoder/bitcoin/bitcoin_p2wpkh_address_encoder_test.dart
+++ b/test/encoder/address_encoder/bitcoin/bitcoin_p2wpkh_address_encoder_test.dart
@@ -1,0 +1,29 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  ECPoint actualPointQ = ECPoint(
+    x: BigInt.parse('76703126420722322007634345723463650715654444727861292197619275780698078484198'),
+    y: BigInt.parse('74654274679389979607131077993714677055519561275235266585538223878569670773020'),
+    z: BigInt.parse('40734431342056095760694605795848451157672234281365399275614292579983211792826'),
+    n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+    curve: Curves.secp256k1,
+  );
+
+  Secp256k1PublicKey actualPublicKey = Secp256k1PublicKey(ecPublicKey: ECPublicKey(CurvePoints.generatorSecp256k1, actualPointQ));
+
+  group('Tests of BitcoinP2WPKHAddressEncoder.encodePublicKey()', () {
+    test('Should [return Bitcoin P2WPKH address] for given public key', () {
+      // Arrange
+      BitcoinP2WPKHAddressEncoder actualBitcoinP2PKHAddressEncoder = BitcoinP2WPKHAddressEncoder(hrp: 'bc');
+
+      // Act
+      String actualAddress = actualBitcoinP2PKHAddressEncoder.encodePublicKey(actualPublicKey);
+
+      // Assert
+      String expectedAddress = 'bc1quxjugvagpv4kz5hdkh7x0qklarw5akdk2sg0wp';
+
+      expect(actualAddress, expectedAddress);
+    });
+  });
+}

--- a/test/encoder/address_encoder/cosmos_address_encoder_test.dart
+++ b/test/encoder/address_encoder/cosmos_address_encoder_test.dart
@@ -1,0 +1,42 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  ECPoint actualPointQ = ECPoint(
+    x: BigInt.parse('103541830980023606809613093633067363502594290705821036222890728111110906420509'),
+    y: BigInt.parse('75808906644622006047938879719654783679105512040910575915102508326553703647166'),
+    z: BigInt.parse('3190226348536498292494465017020441737630476122313049345633869118655223224149'),
+    n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+    curve: Curves.secp256k1,
+  );
+
+  Secp256k1PublicKey actualPublicKey = Secp256k1PublicKey(ecPublicKey: ECPublicKey(CurvePoints.generatorSecp256k1, actualPointQ));
+
+  group('Tests of CosmosAddressEncoder.encodePublicKey()', () {
+    test('Should [return Cosmos address] for given public key (cosmos)', () {
+      // Arrange
+      CosmosAddressEncoder actualCosmosAddressEncoder = CosmosAddressEncoder(hrp: 'cosmos');
+
+      // Act
+      String actualAddress = actualCosmosAddressEncoder.encodePublicKey(actualPublicKey);
+
+      // Assert
+      String expectedAddress = 'cosmos143q8vxpvuykt9pq50e6hng9s38vmy844rgut0t';
+
+      expect(actualAddress, expectedAddress);
+    });
+
+    test('Should [return Cosmos address] for given public key (kira)', () {
+      // Arrange
+      CosmosAddressEncoder actualCosmosAddressEncoder = CosmosAddressEncoder(hrp: 'kira');
+
+      // Act
+      String actualAddress = actualCosmosAddressEncoder.encodePublicKey(actualPublicKey);
+
+      // Assert
+      String expectedAddress = 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx';
+
+      expect(actualAddress, expectedAddress);
+    });
+  });
+}

--- a/test/encoder/address_encoder/ethereum_address_encoder_test.dart
+++ b/test/encoder/address_encoder/ethereum_address_encoder_test.dart
@@ -1,0 +1,42 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  ECPoint actualPointQ = ECPoint(
+    x: BigInt.parse('49844093485842753019501723164709087800134847594852664670182601545797061237061'),
+    y: BigInt.parse('102584019795063234624860865414832132871049165551248963828805190591824528686504'),
+    z: BigInt.parse('33112508886275853310422687256511308836721055527980470378416551104097868981749'),
+    n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+    curve: Curves.secp256k1,
+  );
+
+  Secp256k1PublicKey actualPublicKey = Secp256k1PublicKey(ecPublicKey: ECPublicKey(CurvePoints.generatorSecp256k1, actualPointQ));
+
+  group('Tests of EthereumAddressEncoder.encodePublicKey()', () {
+    test('Should [return Etherum address] [WITH checksum] for given public key', () {
+      // Arrange
+      EthereumAddressEncoder actualEthereumAddressEncoder = EthereumAddressEncoder(skipChecksumBool: false);
+
+      // Act
+      String actualAddress = actualEthereumAddressEncoder.encodePublicKey(actualPublicKey);
+
+      // Assert
+      String expectedAddress = '0x50e10257924889818aA729c6EDfa02524b32Edb9';
+
+      expect(actualAddress, expectedAddress);
+    });
+
+    test('Should [return Etherum address] [WITHOUT checksum] for given public key', () {
+      // Arrange
+      EthereumAddressEncoder actualEthereumAddressEncoder = EthereumAddressEncoder(skipChecksumBool: true);
+
+      // Act
+      String actualAddress = actualEthereumAddressEncoder.encodePublicKey(actualPublicKey);
+
+      // Assert
+      String expectedAddress = '50e10257924889818aa729c6edfa02524b32edb9';
+
+      expect(actualAddress, expectedAddress);
+    });
+  });
+}

--- a/test/encoder/generic_encoder/base/base58_encoder_test.dart
+++ b/test/encoder/generic_encoder/base/base58_encoder_test.dart
@@ -1,0 +1,63 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Tests of Base58Encoder.encode()', () {
+    test('Should [return String] encoded by Base58', () {
+      // Arrange
+      Uint8List actualDataToEncode = base64Decode('Q1JZUFRP');
+
+      // Act
+      String actualBase58Result = Base58Encoder.encode(actualDataToEncode);
+
+      // Assert
+      String expectedBase58Result = 'aXQWBu6W';
+
+      expect(actualBase58Result, expectedBase58Result);
+    });
+
+    test('Should [return String] encoded by Base58 (with checksum)', () {
+      // Arrange
+      Uint8List actualDataToEncode = base64Decode('Q1JZUFRP');
+
+      // Act
+      String actualBase58Result = Base58Encoder.encodeWithChecksum(actualDataToEncode);
+
+      // Assert
+      String expectedBase58Result = '4nNW8qCqV3i7VY';
+
+      expect(actualBase58Result, expectedBase58Result);
+    });
+  });
+
+  group('Tests of Base58Encoder.decode()', () {
+    test('Should [return String] encoded by Base58', () {
+      // Arrange
+      String actualBase58 = 'aXQWBu6W';
+
+      // Act
+      Uint8List actualDecodedData = Base58Encoder.decode(actualBase58);
+
+      // Assert
+      Uint8List expectedDecodedData = base64Decode('Q1JZUFRP');
+
+      expect(actualDecodedData, expectedDecodedData);
+    });
+
+    test('Should [return String] encoded by Base58 (with checksum)', () {
+      // Arrange
+      String actualBase58 = '4nNW8qCqV3i7VY';
+
+      // Act
+      Uint8List actualDecodedData = Base58Encoder.decode(actualBase58);
+
+      // Assert
+      Uint8List expectedDecodedData = base64Decode('Q1JZUFRPndAu1w==');
+
+      expect(actualDecodedData, expectedDecodedData);
+    });
+  });
+}

--- a/test/encoder/generic_encoder/bech32/bech32_encoder_test.dart
+++ b/test/encoder/generic_encoder/bech32/bech32_encoder_test.dart
@@ -1,0 +1,22 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Tests of Bech32Encoder.encode()', () {
+    test('Should [return String] encoded by Bech32', () {
+      // Arrange
+      Uint8List actualDataToEncode = base64Decode('KxmiVli7oFEs8N5rjnzLtw7eym0=');
+
+      // Act
+      String actualEncodedData = Bech32Encoder.encode('crypto', actualDataToEncode);
+
+      // Assert
+      String expectedEncodedData = 'crypto19vv6y4jchws9zt8sme4culxtku8dajndgyhdm2';
+
+      expect(actualEncodedData, expectedEncodedData);
+    });
+  });
+}

--- a/test/encoder/generic_encoder/bech32/segwit_bech32_encoder_test.dart
+++ b/test/encoder/generic_encoder/bech32/segwit_bech32_encoder_test.dart
@@ -1,0 +1,22 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Tests of SegwitBech32Encoder.encode()', () {
+    test('Should [return String] encoded by Bech32 (Segwit version)', () {
+      // Arrange
+      Uint8List actualDataToEncode = base64Decode('KxmiVli7oFEs8N5rjnzLtw7eym0=');
+
+      // Act
+      String actualEncodedData = SegwitBech32Encoder.encode('crypto', 0, actualDataToEncode);
+
+      // Assert
+      String expectedEncodedData = 'crypto1q9vv6y4jchws9zt8sme4culxtku8dajndgp9dmz';
+
+      expect(actualEncodedData, expectedEncodedData);
+    });
+  });
+}

--- a/test/encoder/generic_encoder/hex_encoder_test.dart
+++ b/test/encoder/generic_encoder/hex_encoder_test.dart
@@ -1,0 +1,159 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Uint8List asciiCodeBytes = Uint8List.fromList('123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~'.codeUnits);
+  String hexLowercase =
+      '3132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e';
+  String hexUppercase =
+      '3132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F505152535455565758595A5B5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E';
+
+  group('Tests of HexEncoder.encode()', () {
+    test('Should [return UPPERCASE hexadecimal] from given bytes', () {
+      Uint8List actualDataToEncode = asciiCodeBytes;
+
+      // Act
+      String actualHexResult = HexEncoder.encode(actualDataToEncode, lowercaseBool: false);
+
+      // Assert
+      String expectedHexResult = hexUppercase;
+
+      expect(actualHexResult, expectedHexResult);
+    });
+
+    test('Should [return LOWERCASE hexadecimal] from given bytes', () {
+      Uint8List actualDataToEncode = asciiCodeBytes;
+
+      // Act
+      String actualHexResult = HexEncoder.encode(actualDataToEncode, lowercaseBool: true);
+
+      // Assert
+      String expectedHexResult = hexLowercase;
+
+      expect(actualHexResult, expectedHexResult);
+    });
+  });
+
+  group('Tests of HexEncoder.decode()', () {
+    test('Should [return Uint8List] decoded from given [UPPERCASE hexadecimal] [with 0x prefix]', () {
+      // Arrange
+      String actualHexToDecode = hexUppercase;
+
+      // Act
+      Uint8List actualDecodedHexResult = HexEncoder.decode('0x$actualHexToDecode');
+
+      // Assert
+      Uint8List expectedDecodedHexResult = asciiCodeBytes;
+
+      expect(actualDecodedHexResult, expectedDecodedHexResult);
+    });
+
+    test('Should [return Uint8List] decoded from given [UPPERCASE hexadecimal] [without 0x prefix]', () {
+      // Arrange
+      String actualHexToDecode = hexUppercase;
+
+      // Act
+      Uint8List actualDecodedHexResult = HexEncoder.decode(actualHexToDecode);
+
+      // Assert
+      Uint8List expectedDecodedHexResult = asciiCodeBytes;
+
+      expect(actualDecodedHexResult, expectedDecodedHexResult);
+    });
+
+    test('Should [return Uint8List] decoded from given [LOWERCASE hexadecimal] [with 0x prefix]', () {
+      // Arrange
+      String actualHexToDecode = hexLowercase;
+
+      // Act
+      Uint8List actualDecodedHexResult = HexEncoder.decode('0x$actualHexToDecode');
+
+      // Assert
+      Uint8List expectedDecodedHexResult = asciiCodeBytes;
+
+      expect(actualDecodedHexResult, expectedDecodedHexResult);
+    });
+
+    test('Should [return Uint8List] decoded from given [LOWERCASE hexadecimal] [without 0x prefix]', () {
+      // Arrange
+      String actualHexToDecode = hexLowercase;
+
+      // Act
+      Uint8List actualDecodedHexResult = HexEncoder.decode(actualHexToDecode);
+
+      // Assert
+      Uint8List expectedDecodedHexResult = asciiCodeBytes;
+
+      expect(actualDecodedHexResult, expectedDecodedHexResult);
+    });
+  });
+
+  group('Tests of HexEncoder.isHex()', () {
+    test('Should [return TRUE] if given value is [UPPERCASE hexadecimal] [with 0x prefix]', () {
+      // Arrange
+      String actualHexToCheck = '0x$hexUppercase';
+
+      // Act
+      bool actualHexBool = HexEncoder.isHex(actualHexToCheck);
+
+      // Assert
+      bool expectedHexBool = true;
+
+      expect(actualHexBool, expectedHexBool);
+    });
+
+    test('Should [return TRUE] if given value is [UPPERCASE hexadecimal] [without 0x prefix]', () {
+      // Arrange
+      String actualHexToCheck = hexUppercase;
+
+      // Act
+      bool actualHexBool = HexEncoder.isHex(actualHexToCheck);
+
+      // Assert
+      bool expectedHexBool = true;
+
+      expect(actualHexBool, expectedHexBool);
+    });
+
+    test('Should [return TRUE] if given value is [LOWERCASE hexadecimal] [with 0x prefix]', () {
+      // Arrange
+      String actualHexToCheck = '0x$hexLowercase';
+
+      // Act
+      bool actualHexBool = HexEncoder.isHex(actualHexToCheck);
+
+      // Assert
+      bool expectedHexBool = true;
+
+      expect(actualHexBool, expectedHexBool);
+    });
+
+    test('Should [return TRUE] if given value is [LOWERCASE hexadecimal] [without 0x prefix]', () {
+      // Arrange
+      String actualHexToCheck = hexLowercase;
+
+      // Act
+      bool actualHexBool = HexEncoder.isHex(actualHexToCheck);
+
+      // Assert
+      bool expectedHexBool = true;
+
+      expect(actualHexBool, expectedHexBool);
+    });
+
+    test('Should [return FALSE] if given value is [NOT hexadecimal]', () {
+      // Arrange
+      String actualHexToCheck = 'random string';
+
+      // Act
+      bool actualHexBool = HexEncoder.isHex(actualHexToCheck);
+
+      // Assert
+      bool expectedHexBool = false;
+
+      expect(actualHexBool, expectedHexBool);
+    });
+  });
+}

--- a/test/hash/keccak_test.dart
+++ b/test/hash/keccak_test.dart
@@ -1,0 +1,71 @@
+import 'dart:convert';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Uint8List actualDataToHash = Uint8List.fromList('123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~'.codeUnits);
+
+  group('Tests of Keccak.process()', () {
+    test('Should [return Keccak128 HASH] constructed from given data', () {
+      // Act
+      Uint8List actualKeccakResult = Keccak(128).process(actualDataToHash);
+
+      // Assert
+      Uint8List expectedKeccakResult = base64Decode('2Rbrmj3BGkVcYzxWf3zQhw==');
+
+      expect(actualKeccakResult, expectedKeccakResult);
+    });
+
+    test('Should [return Keccak224 HASH] constructed from given data', () {
+      // Act
+      Uint8List actualKeccakResult = Keccak(224).process(actualDataToHash);
+
+      // Assert
+      Uint8List expectedKeccakResult = base64Decode('h3ZKJczNIEckiGE1zv38YNvm9Lig+oYr2fiGAg==');
+
+      expect(actualKeccakResult, expectedKeccakResult);
+    });
+
+    test('Should [return Keccak256 HASH] constructed from given data', () {
+      // Act
+      Uint8List actualKeccakResult = Keccak(256).process(actualDataToHash);
+
+      // Assert
+      Uint8List expectedKeccakResult = base64Decode('BCh2dEOFXrYvTet6a/a3PPmwZvQ7KQb60c8ib9WqhfE=');
+
+      expect(actualKeccakResult, expectedKeccakResult);
+    });
+
+    test('Should [return Keccak288 HASH] constructed from given data', () {
+      // Act
+      Uint8List actualKeccakResult = Keccak(288).process(actualDataToHash);
+
+      // Assert
+      Uint8List expectedKeccakResult = base64Decode('KPDYH5BgWlRRteR9Hm+lL8Tmv7krLpj/pABDV53+vY3azshS');
+
+      expect(actualKeccakResult, expectedKeccakResult);
+    });
+
+    test('Should [return Keccak384 HASH] constructed from given data', () {
+      // Act
+      Uint8List actualKeccakResult = Keccak(384).process(actualDataToHash);
+
+      // Assert
+      Uint8List expectedKeccakResult = base64Decode('hK/d5Vo4YuG2z90PuXxsXahV1Wk7OTB2Tv7IGkPNmScppcbc0z81cdCuG62GWZ9h');
+
+      expect(actualKeccakResult, expectedKeccakResult);
+    });
+
+    test('Should [return Keccak512 HASH] constructed from given data', () {
+      // Act
+      Uint8List actualKeccakResult = Keccak(512).process(actualDataToHash);
+
+      // Assert
+      Uint8List expectedKeccakResult = base64Decode('jlBELCX09gYSS5Io1R2gRyLi55O9uFl5d2GyjffXA6WFbUhPlLQyZ/W4ifqpD/CntMJrcvL3VUFuO3Xck/A6Og==');
+
+      expect(actualKeccakResult, expectedKeccakResult);
+    });
+  });
+}

--- a/test/hash/ripemd160_test.dart
+++ b/test/hash/ripemd160_test.dart
@@ -1,0 +1,21 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Uint8List actualDataToHash = Uint8List.fromList('123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~'.codeUnits);
+
+  group('Tests of Ripemd160.process()', () {
+    test('Should [return Ripemd160 HASH] constructed from given data', () {
+      // Act
+      Uint8List actualRipemd160Result = Ripemd160().process(actualDataToHash);
+
+      // Assert
+      Uint8List expectedRipemd160Result = base64Decode('iJS43Wf/c7ZqtImU2HYR0laE3q4=');
+
+      expect(actualRipemd160Result, expectedRipemd160Result);
+    });
+  });
+}


### PR DESCRIPTION
The goal of this branch is to implement public addresses encoders for certain networks based on Secp256k1 curve (Bitcoin, Ethereum, Cosmos, Kira).

List of changes:
- created bitcoin_p2pkh_address_encoder.dart, bitcoin_p2sh_address_encoder.dart, bitcoin_p2wpkh_address_encoder.dart to build Bitcoin addresses in accordance with BIP-44, BIP-49, BIP-84
- created ethereum_address_encoder.dart to build hexadecimal addresses used within Ethereum network
- created cosmos_address_encoders.dart to build BECH32 addresses used within Cosmos network and networks based on Cosmos ecosystem (e.g. KIRA)
- created bech32_encoder.dart, segwit_bech32_encoder.dart to encode data in accordance with BECH32 algorithm. For the work organisation purposes these classes use external package, which will be changed on the next branches.
- created hex_encoder.dart containing operations to simplify parsing bytes to HEX and HEX to bytes
- created base58_encoder.dart to encode data in accordance with Base58 standard
- created keccak.dart, ripemd160.dart - hashing algorithms used in address encoders. For the work organisation purposes these classes use external package, which will be changed on the next branches.
- added new "addressEncoder" parameter to a_wallet_config.dart to allow defining different addresses for different networks
- added new "address" parameter to hd_wallet.dart containing generated address as String