### PR TITLE
Refactor: Mnemonic validation

### DIFF
--- a/lib/src/bip/bip39/bip39.dart
+++ b/lib/src/bip/bip39/bip39.dart
@@ -1,5 +1,7 @@
 export 'mnemonic.dart';
 export 'mnemonic_dictionary.dart';
+export 'mnemonic_exception.dart';
+export 'mnemonic_exception_type.dart';
 export 'mnemonic_seed_generator/a_mnemonic_seed_generator.dart';
 export 'mnemonic_seed_generator/entropy_mnemonic_seed_generator.dart';
 export 'mnemonic_seed_generator/legacy_mnemonic_seed_generator.dart';

--- a/lib/src/bip/bip39/mnemonic.dart
+++ b/lib/src/bip/bip39/mnemonic.dart
@@ -8,78 +8,100 @@ import 'package:flutter/foundation.dart';
 /// This functionality is typically used in the context of cryptocurrency wallets for generating private-keys in a way that is easier for users to record and remember.
 /// https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
 class Mnemonic extends Equatable {
+  static const int _mnemonicWordNotFoundInDictionary = -1;
   final List<String> mnemonicList;
 
-  const Mnemonic(this.mnemonicList);
+  // Validation of a mnemonic phrase requires to check its length, checksum and words.
+  // To do this before the object is created - in the factory constructor, all public methods contained in this class must be static,
+  // Such a solution would be less readable and less intuitive. For that reason, the validation and exception throwing are done in the constructor.
+  Mnemonic(this.mnemonicList) {
+    if (mnemonicList.length % 3 != 0 || mnemonicList.isEmpty) {
+      throw const MnemonicException(MnemonicExceptionType.invalidLength);
+    } else if (_mnemonicListIndexes.contains(_mnemonicWordNotFoundInDictionary)) {
+      throw const MnemonicException(MnemonicExceptionType.invalidWord);
+    }
 
-  /// Generates a new random mnemonic phrase of the specified size.
+    String extractedChecksum = _extractChecksum();
+    String calculatedChecksum = _calculateChecksum(entropy);
+
+    if (extractedChecksum != calculatedChecksum) {
+      throw const MnemonicException(MnemonicExceptionType.invalidChecksum);
+    }
+  }
+
+  /// Generates a new [Mnemonic] object of the specified size.
   factory Mnemonic.generate({required MnemonicSize mnemonicSize}) {
     Uint8List entropy = SecureRandom.getBytes(length: mnemonicSize.entropyBytesSize, max: 255);
+
     return Mnemonic.fromEntropy(entropy);
   }
 
-  /// Generates a new mnemonic phrase from the provided entropy.
+  /// Constructs a new [Mnemonic] object from the entropy.
   factory Mnemonic.fromEntropy(Uint8List entropy) {
     String entropyBits = BinaryUtils.bytesToBinary(entropy);
-    String checksumBits = _calcBinaryChecksum(entropy);
+    String checksumBits = _calculateChecksum(entropy);
     String mnemonicBits = entropyBits + checksumBits;
 
-    List<String> wordBinaries = BinaryUtils.splitBinary(mnemonicBits, 11);
+    List<String> mnemonicListBinaries = BinaryUtils.splitBinary(mnemonicBits, 11);
+    List<int> mnemonicListIndexes = mnemonicListBinaries.map(BinaryUtils.binaryToInt).toList();
+    List<String> mnemonicList = mnemonicListIndexes.map((int index) => MnemonicDictionary.english[index]).toList();
 
-    List<int> wordIndexes = wordBinaries.map(BinaryUtils.binaryToInt).toList();
-    List<String> words = wordIndexes.map((int index) => MnemonicDictionary.english[index]).toList();
-
-    return Mnemonic(words);
+    return Mnemonic(mnemonicList);
   }
 
-  /// Parses a mnemonic phrase from a string.
-  Mnemonic.fromString(String mnemonicString, {String delimiter = ' '}) : mnemonicList = mnemonicString.split(delimiter);
+  /// Constructs a new [Mnemonic] object from the mnemonic phrase.
+  factory Mnemonic.fromMnemonicPhrase(String mnemonicPhrase, {String delimiter = ' '}) {
+    List<String> mnemonicList = mnemonicPhrase.split(delimiter);
 
-  bool get isValid {
-    try {
-      Uint8List tmpEntropy = entropy;
-      return tmpEntropy.isNotEmpty;
-    } catch (e) {
-      return false;
-    }
+    return Mnemonic(mnemonicList);
   }
 
+  /// Returns the entropy of the mnemonic phrase.
   Uint8List get entropy {
-    if (mnemonicList.length % 3 != 0) {
-      throw Exception('Invalid mnemonic');
-    }
+    String mnemonicBits = _mnemonicBits;
 
-    List<int> wordIndexes = mnemonicList.map(MnemonicDictionary.english.indexOf).toList();
-    if (wordIndexes.contains(-1)) {
-      throw Exception('Invalid mnemonic');
-    }
+    int entropyStartIndex = 0;
+    int entropyEndIndex = (mnemonicBits.length / 33).floor() * 32;
 
-    List<String> wordBinaries = wordIndexes.map((int index) => BinaryUtils.intToBinary(index, padding: 11)).toList();
-    String mnemonicBits = wordBinaries.join('');
-
-    int dividerIndex = (mnemonicBits.length / 33).floor() * 32;
-    String entropyBits = mnemonicBits.substring(0, dividerIndex);
-    String expectedChecksumBits = mnemonicBits.substring(dividerIndex);
-
+    String entropyBits = mnemonicBits.substring(entropyStartIndex, entropyEndIndex);
     List<String> entropyBinaries = BinaryUtils.splitBinary(entropyBits, 8);
     Uint8List entropy = Uint8List.fromList(entropyBinaries.map(BinaryUtils.binaryToInt).toList());
-
-    String actualChecksumBits = _calcBinaryChecksum(entropy);
-    if (actualChecksumBits != expectedChecksumBits) {
-      throw Exception('Invalid checksum');
-    }
 
     return entropy;
   }
 
-  int get length => mnemonicList.length;
-
-  static String _calcBinaryChecksum(Uint8List entropy) {
+  /// Calculates the checksum of the mnemonic phrase basing on given entropy.
+  static String _calculateChecksum(Uint8List entropy) {
     int entropyBitsLength = entropy.length * 8;
     int checksumSize = entropyBitsLength ~/ 32;
     List<int> hash = sha256.convert(entropy).bytes;
+
     return BinaryUtils.bytesToBinary(hash).substring(0, checksumSize);
   }
+
+  /// Returns binary checksum included in the last word of the mnemonic phrase.
+  String _extractChecksum() {
+    String mnemonicBits = _mnemonicBits;
+
+    int checksumStartIndex = (mnemonicBits.length / 33).floor() * 32;
+    int checksumEndIndex = mnemonicBits.length;
+
+    String checksum = mnemonicBits.substring(checksumStartIndex, checksumEndIndex);
+
+    return checksum;
+  }
+
+  /// Returns the combined mnemonic words in binary format.
+  String get _mnemonicBits {
+    List<String> mnemonicListBinaries = _mnemonicListIndexes.map((int index) => BinaryUtils.intToBinary(index, padding: 11)).toList();
+    String mnemonicBits = mnemonicListBinaries.join('');
+
+    return mnemonicBits;
+  }
+
+  /// Returns dictionary indexes of the mnemonic words.
+  /// If a word is not found in the dictionary, it will be represented as -1.
+  List<int> get _mnemonicListIndexes => mnemonicList.map(MnemonicDictionary.english.indexOf).toList();
 
   @override
   String toString() {

--- a/lib/src/bip/bip39/mnemonic_exception.dart
+++ b/lib/src/bip/bip39/mnemonic_exception.dart
@@ -1,0 +1,11 @@
+import 'package:cryptography_utils/src/bip/bip39/mnemonic_exception_type.dart';
+import 'package:equatable/equatable.dart';
+
+class MnemonicException extends Equatable implements Exception {
+  final MnemonicExceptionType mnemonicExceptionType;
+
+  const MnemonicException(this.mnemonicExceptionType);
+
+  @override
+  List<Object?> get props => <Object?>[mnemonicExceptionType];
+}

--- a/lib/src/bip/bip39/mnemonic_exception_type.dart
+++ b/lib/src/bip/bip39/mnemonic_exception_type.dart
@@ -1,0 +1,5 @@
+enum MnemonicExceptionType {
+  invalidChecksum,
+  invalidLength,
+  invalidWord,
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cryptography_utils
 description: "Cryptography utils"
-version: 0.0.6
+version: 0.0.7
 
 environment:
   sdk: ">=3.2.2"

--- a/test/bip/bip32/derivators/legacy_derivators/secp256k1_derivator_test.dart
+++ b/test/bip/bip32/derivators/legacy_derivators/secp256k1_derivator_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   Secp256k1Derivator actualSecp256k1Derivator = Secp256k1Derivator();
-  Mnemonic actualMnemonic = Mnemonic.fromString(
+  Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase(
       'require point property company tongue busy bench burden caution gadget knee glance thought bulk assist month cereal report quarter tool section often require shield');
 
   group('Secp256k1Derivator.derivePath()', () {

--- a/test/bip/bip32/hd_wallet/legacy_hd_wallet_test.dart
+++ b/test/bip/bip32/hd_wallet/legacy_hd_wallet_test.dart
@@ -4,7 +4,7 @@ import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  Mnemonic mnemonic = Mnemonic.fromString(
+  Mnemonic mnemonic = Mnemonic.fromMnemonicPhrase(
       'require point property company tongue busy bench burden caution gadget knee glance thought bulk assist month cereal report quarter tool section often require shield');
 
   group('Tests of LegacyHDWallet.fromMnemonic()', () {

--- a/test/bip/bip39/mnemonic_seed_generator/entropy_mnemonic_seed_generator_test.dart
+++ b/test/bip/bip39/mnemonic_seed_generator/entropy_mnemonic_seed_generator_test.dart
@@ -9,7 +9,7 @@ void main() {
     test('Should [return 32-bytes seed] constructed from [12-word Mnemonic]', () async {
       // Arrange
       EntropyMnemonicSeedGenerator actualEntropyMnemonicSeedGenerator = EntropyMnemonicSeedGenerator();
-      Mnemonic actualMnemonic = Mnemonic.fromString('media seminar seminar gentle stumble smooth salon zebra visual gasp usual rough');
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase('media seminar seminar gentle stumble smooth salon zebra visual gasp usual rough');
 
       // Act
       Uint8List actualSeed = await actualEntropyMnemonicSeedGenerator.generateSeed(actualMnemonic);
@@ -22,7 +22,7 @@ void main() {
     test('Should [return 32-bytes seed] constructed from [15-word Mnemonic]', () async {
       // Arrange
       EntropyMnemonicSeedGenerator actualEntropyMnemonicSeedGenerator = EntropyMnemonicSeedGenerator();
-      Mnemonic actualMnemonic = Mnemonic.fromString('doctor arrange before lift parade husband gadget orchard omit milk guilt biology act beauty dice');
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase('doctor arrange before lift parade husband gadget orchard omit milk guilt biology act beauty dice');
 
       // Act
       Uint8List actualSeed = await actualEntropyMnemonicSeedGenerator.generateSeed(actualMnemonic);
@@ -36,7 +36,7 @@ void main() {
       // Arrange
       EntropyMnemonicSeedGenerator actualEntropyMnemonicSeedGenerator = EntropyMnemonicSeedGenerator();
       Mnemonic actualMnemonic =
-          Mnemonic.fromString('sense wet coach stage sheriff bargain wrap advance slide timber leave ski famous label pyramid debate sort fatal');
+          Mnemonic.fromMnemonicPhrase('sense wet coach stage sheriff bargain wrap advance slide timber leave ski famous label pyramid debate sort fatal');
 
       // Act
       Uint8List actualSeed = await actualEntropyMnemonicSeedGenerator.generateSeed(actualMnemonic);
@@ -49,7 +49,7 @@ void main() {
     test('Should [return 32-bytes seed] constructed from [21-word Mnemonic]', () async {
       // Arrange
       EntropyMnemonicSeedGenerator actualEntropyMnemonicSeedGenerator = EntropyMnemonicSeedGenerator();
-      Mnemonic actualMnemonic = Mnemonic.fromString(
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase(
           'fatal flame spike bless razor prevent rally human stamp kiwi cause raise always discover chef wide program bless fold celery immense');
 
       // Act
@@ -63,7 +63,7 @@ void main() {
     test('Should [return 32-bytes seed] constructed from [24-word Mnemonic]', () async {
       // Arrange
       EntropyMnemonicSeedGenerator actualEntropyMnemonicSeedGenerator = EntropyMnemonicSeedGenerator();
-      Mnemonic actualMnemonic = Mnemonic.fromString(
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase(
           'track resist blood salute popular pride salon receive weather tornado wink tackle few trend embrace burst zebra mind siege tower shift joy flash awkward');
 
       // Act
@@ -79,7 +79,7 @@ void main() {
     test('Should [return 64-bytes seed] constructed from [12-word Mnemonic]', () async {
       // Arrange
       EntropyMnemonicSeedGenerator actualEntropyMnemonicSeedGenerator = EntropyMnemonicSeedGenerator(seedLength: 64);
-      Mnemonic actualMnemonic = Mnemonic.fromString('media seminar seminar gentle stumble smooth salon zebra visual gasp usual rough');
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase('media seminar seminar gentle stumble smooth salon zebra visual gasp usual rough');
 
       // Act
       Uint8List actualSeed = await actualEntropyMnemonicSeedGenerator.generateSeed(actualMnemonic);
@@ -92,7 +92,7 @@ void main() {
     test('Should [return 64-bytes seed] constructed from [15-word Mnemonic]', () async {
       // Arrange
       EntropyMnemonicSeedGenerator actualEntropyMnemonicSeedGenerator = EntropyMnemonicSeedGenerator(seedLength: 64);
-      Mnemonic actualMnemonic = Mnemonic.fromString('doctor arrange before lift parade husband gadget orchard omit milk guilt biology act beauty dice');
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase('doctor arrange before lift parade husband gadget orchard omit milk guilt biology act beauty dice');
 
       // Act
       Uint8List actualSeed = await actualEntropyMnemonicSeedGenerator.generateSeed(actualMnemonic);
@@ -106,7 +106,7 @@ void main() {
       // Arrange
       EntropyMnemonicSeedGenerator actualEntropyMnemonicSeedGenerator = EntropyMnemonicSeedGenerator(seedLength: 64);
       Mnemonic actualMnemonic =
-          Mnemonic.fromString('sense wet coach stage sheriff bargain wrap advance slide timber leave ski famous label pyramid debate sort fatal');
+          Mnemonic.fromMnemonicPhrase('sense wet coach stage sheriff bargain wrap advance slide timber leave ski famous label pyramid debate sort fatal');
 
       // Act
       Uint8List actualSeed = await actualEntropyMnemonicSeedGenerator.generateSeed(actualMnemonic);
@@ -119,7 +119,7 @@ void main() {
     test('Should [return 64-bytes seed] constructed from [21-word Mnemonic]', () async {
       // Arrange
       EntropyMnemonicSeedGenerator actualEntropyMnemonicSeedGenerator = EntropyMnemonicSeedGenerator(seedLength: 64);
-      Mnemonic actualMnemonic = Mnemonic.fromString(
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase(
           'fatal flame spike bless razor prevent rally human stamp kiwi cause raise always discover chef wide program bless fold celery immense');
 
       // Act
@@ -133,7 +133,7 @@ void main() {
     test('Should [return 64-bytes seed] constructed from [24-word Mnemonic]', () async {
       // Arrange
       EntropyMnemonicSeedGenerator actualEntropyMnemonicSeedGenerator = EntropyMnemonicSeedGenerator(seedLength: 64);
-      Mnemonic actualMnemonic = Mnemonic.fromString(
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase(
           'track resist blood salute popular pride salon receive weather tornado wink tackle few trend embrace burst zebra mind siege tower shift joy flash awkward');
 
       // Act

--- a/test/bip/bip39/mnemonic_seed_generator/legacy_mnemonic_seed_generator_test.dart
+++ b/test/bip/bip39/mnemonic_seed_generator/legacy_mnemonic_seed_generator_test.dart
@@ -9,7 +9,7 @@ void main() {
     test('Should [return 32-bytes seed] constructed from [12-word Mnemonic]', () async {
       // Arrange
       LegacyMnemonicSeedGenerator actualLegacyMnemonicSeedGenerator = LegacyMnemonicSeedGenerator(seedLength: 32);
-      Mnemonic actualMnemonic = Mnemonic.fromString('media seminar seminar gentle stumble smooth salon zebra visual gasp usual rough');
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase('media seminar seminar gentle stumble smooth salon zebra visual gasp usual rough');
 
       // Act
       Uint8List actualSeed = await actualLegacyMnemonicSeedGenerator.generateSeed(actualMnemonic);
@@ -22,7 +22,7 @@ void main() {
     test('Should [return 32-bytes seed] constructed from [15-word Mnemonic]', () async {
       // Arrange
       LegacyMnemonicSeedGenerator actualLegacyMnemonicSeedGenerator = LegacyMnemonicSeedGenerator(seedLength: 32);
-      Mnemonic actualMnemonic = Mnemonic.fromString('doctor arrange before lift parade husband gadget orchard omit milk guilt biology act beauty dice');
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase('doctor arrange before lift parade husband gadget orchard omit milk guilt biology act beauty dice');
 
       // Act
       Uint8List actualSeed = await actualLegacyMnemonicSeedGenerator.generateSeed(actualMnemonic);
@@ -36,7 +36,7 @@ void main() {
       // Arrange
       LegacyMnemonicSeedGenerator actualLegacyMnemonicSeedGenerator = LegacyMnemonicSeedGenerator(seedLength: 32);
       Mnemonic actualMnemonic =
-          Mnemonic.fromString('sense wet coach stage sheriff bargain wrap advance slide timber leave ski famous label pyramid debate sort fatal');
+          Mnemonic.fromMnemonicPhrase('sense wet coach stage sheriff bargain wrap advance slide timber leave ski famous label pyramid debate sort fatal');
 
       // Act
       Uint8List actualSeed = await actualLegacyMnemonicSeedGenerator.generateSeed(actualMnemonic);
@@ -49,7 +49,7 @@ void main() {
     test('Should [return 32-bytes seed] constructed from [21-word Mnemonic]', () async {
       // Arrange
       LegacyMnemonicSeedGenerator actualLegacyMnemonicSeedGenerator = LegacyMnemonicSeedGenerator(seedLength: 32);
-      Mnemonic actualMnemonic = Mnemonic.fromString(
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase(
           'fatal flame spike bless razor prevent rally human stamp kiwi cause raise always discover chef wide program bless fold celery immense');
 
       // Act
@@ -63,7 +63,7 @@ void main() {
     test('Should [return 32-bytes seed] constructed from [24-word Mnemonic]', () async {
       // Arrange
       LegacyMnemonicSeedGenerator actualLegacyMnemonicSeedGenerator = LegacyMnemonicSeedGenerator(seedLength: 32);
-      Mnemonic actualMnemonic = Mnemonic.fromString(
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase(
           'track resist blood salute popular pride salon receive weather tornado wink tackle few trend embrace burst zebra mind siege tower shift joy flash awkward');
 
       // Act
@@ -79,7 +79,7 @@ void main() {
     test('Should [return 64-bytes seed] constructed from [12-word Mnemonic]', () async {
       // Arrange
       LegacyMnemonicSeedGenerator actualLegacyMnemonicSeedGenerator = LegacyMnemonicSeedGenerator();
-      Mnemonic actualMnemonic = Mnemonic.fromString('media seminar seminar gentle stumble smooth salon zebra visual gasp usual rough');
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase('media seminar seminar gentle stumble smooth salon zebra visual gasp usual rough');
 
       // Act
       Uint8List actualSeed = await actualLegacyMnemonicSeedGenerator.generateSeed(actualMnemonic);
@@ -92,7 +92,7 @@ void main() {
     test('Should [return 64-bytes seed] constructed from [15-word Mnemonic]', () async {
       // Arrange
       LegacyMnemonicSeedGenerator actualLegacyMnemonicSeedGenerator = LegacyMnemonicSeedGenerator();
-      Mnemonic actualMnemonic = Mnemonic.fromString('doctor arrange before lift parade husband gadget orchard omit milk guilt biology act beauty dice');
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase('doctor arrange before lift parade husband gadget orchard omit milk guilt biology act beauty dice');
 
       // Act
       Uint8List actualSeed = await actualLegacyMnemonicSeedGenerator.generateSeed(actualMnemonic);
@@ -106,7 +106,7 @@ void main() {
       // Arrange
       LegacyMnemonicSeedGenerator actualLegacyMnemonicSeedGenerator = LegacyMnemonicSeedGenerator();
       Mnemonic actualMnemonic =
-          Mnemonic.fromString('sense wet coach stage sheriff bargain wrap advance slide timber leave ski famous label pyramid debate sort fatal');
+          Mnemonic.fromMnemonicPhrase('sense wet coach stage sheriff bargain wrap advance slide timber leave ski famous label pyramid debate sort fatal');
 
       // Act
       Uint8List actualSeed = await actualLegacyMnemonicSeedGenerator.generateSeed(actualMnemonic);
@@ -119,7 +119,7 @@ void main() {
     test('Should [return 64-bytes seed] constructed from [21-word Mnemonic]', () async {
       // Arrange
       LegacyMnemonicSeedGenerator actualLegacyMnemonicSeedGenerator = LegacyMnemonicSeedGenerator();
-      Mnemonic actualMnemonic = Mnemonic.fromString(
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase(
           'fatal flame spike bless razor prevent rally human stamp kiwi cause raise always discover chef wide program bless fold celery immense');
 
       // Act
@@ -133,7 +133,7 @@ void main() {
     test('Should [return 64-bytes seed] constructed from [24-word Mnemonic]', () async {
       // Arrange
       LegacyMnemonicSeedGenerator actualLegacyMnemonicSeedGenerator = LegacyMnemonicSeedGenerator();
-      Mnemonic actualMnemonic = Mnemonic.fromString(
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase(
           'track resist blood salute popular pride salon receive weather tornado wink tackle few trend embrace burst zebra mind siege tower shift joy flash awkward');
 
       // Act

--- a/test/bip/bip39/mnemonic_test.dart
+++ b/test/bip/bip39/mnemonic_test.dart
@@ -5,6 +5,49 @@ import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  group('Tests of Mnemonic() constructor', () {
+    test('Should [return Mnemonic] from given mnemonic phrase', () {
+      // Arrange
+      List<String> actualMnemonicList = <String>['catalog', 'letter', 'frown', 'ramp', 'chest', 'van', 'pole', 'unfold', 'sound', 'unable', 'cool', 'endorse'];
+
+      // Act
+      Mnemonic actualMnemonic = Mnemonic(actualMnemonicList);
+
+      // Assert
+      // @formatter:off
+      List<String> expectedMnemonicList = <String>['catalog', 'letter', 'frown', 'ramp', 'chest', 'van', 'pole', 'unfold', 'sound', 'unable', 'cool', 'endorse'];
+      // @formatter:on
+
+      expect(actualMnemonic.mnemonicList, expectedMnemonicList);
+    });
+
+    test('Should [throw MnemonicException] (MnemonicExceptionType.invalidLength) if length of the mnemonic phrase is not divisible by 3', () {
+      // Assert
+      expect(
+        () => Mnemonic(const <String>['catalog', 'letter', 'frown', 'ramp', 'chest', 'van', 'unfold', 'sound', 'unable', 'cool', 'endorse']),
+        throwsA(const MnemonicException(MnemonicExceptionType.invalidLength)),
+      );
+    });
+
+    test('Should [throw MnemonicException] (MnemonicExceptionType.invalidWord) if mnemonic phrase contains words from outside the dictionary', () {
+      // Assert
+      // @formatter:off
+      expect(
+        () =>  Mnemonic(const <String>['ammonium', 'nitrite', 'atom', 'hydrogen', 'cyanide', 'carbonate', 'chlorate', 'chlorite', 'perchlorate', 'cation', 'peroxide', 'oxalate']),
+        throwsA(const MnemonicException(MnemonicExceptionType.invalidWord)),
+      );
+      // @formatter:on
+    });
+
+    test('Should [throw MnemonicException] (MnemonicExceptionType.invalidChecksum) if mnemonic phrase has invalid checksum', () {
+      // Assert
+      expect(
+        () => Mnemonic(const <String>['catalog', 'letter', 'frown', 'ramp', 'chest', 'van', 'pole', 'unfold', 'sound', 'unable', 'cool', 'require']),
+        throwsA(const MnemonicException(MnemonicExceptionType.invalidChecksum)),
+      );
+    });
+  });
+
   group('Tests of Mnemonic.generate() constructor', () {
     test('Should [return 12-word Mnemonic] from random entropy', () {
       // Act
@@ -14,7 +57,6 @@ void main() {
       // Mnemonic generation is an random process, so we can't check the expected result.
       // Because of that we only verify that it has 12 words and that it is valid.
       expect(actualMnemonic.mnemonicList.length, 12);
-      expect(actualMnemonic.isValid, true);
     });
 
     test('Should [return 15-word Mnemonic] from random entropy', () {
@@ -25,7 +67,6 @@ void main() {
       // Mnemonic generation is an random process, so we can't check the expected result.
       // Because of that we only verify that it has 15 words and that it is valid.
       expect(actualMnemonic.mnemonicList.length, 15);
-      expect(actualMnemonic.isValid, true);
     });
 
     test('Should [return 18-word Mnemonic] from random entropy', () {
@@ -36,7 +77,6 @@ void main() {
       // Mnemonic generation is an random process, so we can't check the expected result.
       // Because of that we only verify that it has 18 words and that it is valid.
       expect(actualMnemonic.mnemonicList.length, 18);
-      expect(actualMnemonic.isValid, true);
     });
 
     test('Should [return 21-word Mnemonic] from random entropy', () {
@@ -47,7 +87,6 @@ void main() {
       // Mnemonic generation is an random process, so we can't check the expected result.
       // Because of that we only verify that it has 21 words and that it is valid.
       expect(actualMnemonic.mnemonicList.length, 21);
-      expect(actualMnemonic.isValid, true);
     });
 
     test('Should [return 24-word Mnemonic] from random entropy', () {
@@ -58,7 +97,6 @@ void main() {
       // Mnemonic generation is an random process, so we can't check the expected result.
       // Because of that we only verify that it has 24 words and that it is valid.
       expect(actualMnemonic.mnemonicList.length, 24);
-      expect(actualMnemonic.isValid, true);
     });
   });
 
@@ -71,7 +109,7 @@ void main() {
       Mnemonic actualMnemonic = Mnemonic.fromEntropy(actualEntropy);
 
       // Assert
-      Mnemonic expectedMnemonic = Mnemonic.fromString('admit decide brave dinosaur patch fresh april toward elite clutch toy witness');
+      Mnemonic expectedMnemonic = Mnemonic.fromMnemonicPhrase('admit decide brave dinosaur patch fresh april toward elite clutch toy witness');
 
       expect(actualMnemonic.mnemonicList, expectedMnemonic.mnemonicList);
     });
@@ -84,7 +122,7 @@ void main() {
       Mnemonic actualMnemonic = Mnemonic.fromEntropy(actualEntropy);
 
       // Assert
-      Mnemonic expectedMnemonic = Mnemonic.fromString('lake stumble pencil clog add scan resource attend huge space three salon hip shift drama');
+      Mnemonic expectedMnemonic = Mnemonic.fromMnemonicPhrase('lake stumble pencil clog add scan resource attend huge space three salon hip shift drama');
 
       expect(actualMnemonic.mnemonicList, expectedMnemonic.mnemonicList);
     });
@@ -97,8 +135,8 @@ void main() {
       Mnemonic actualMnemonic = Mnemonic.fromEntropy(actualEntropy);
 
       // Assert
-      Mnemonic expectedMnemonic =
-          Mnemonic.fromString('very erosion proud virus remain pony dignity hat tornado art enhance enhance rabbit add hospital buffalo gallery journey');
+      Mnemonic expectedMnemonic = Mnemonic.fromMnemonicPhrase(
+          'very erosion proud virus remain pony dignity hat tornado art enhance enhance rabbit add hospital buffalo gallery journey');
 
       expect(actualMnemonic.mnemonicList, expectedMnemonic.mnemonicList);
     });
@@ -111,7 +149,7 @@ void main() {
       Mnemonic actualMnemonic = Mnemonic.fromEntropy(actualEntropy);
 
       // Assert
-      Mnemonic expectedMnemonic = Mnemonic.fromString(
+      Mnemonic expectedMnemonic = Mnemonic.fromMnemonicPhrase(
           'concert tired breeze call boy business chronic fox crater fire arctic universe void remember giraffe fetch hint select sound insect sister');
 
       expect(actualMnemonic.mnemonicList, expectedMnemonic.mnemonicList);
@@ -125,93 +163,71 @@ void main() {
       Mnemonic actualMnemonic = Mnemonic.fromEntropy(actualEntropy);
 
       // Assert
-      Mnemonic expectedMnemonic = Mnemonic.fromString(
+      Mnemonic expectedMnemonic = Mnemonic.fromMnemonicPhrase(
           'kiwi prosper empty sphere recall predict border bridge adult grid hunt confirm spread priority decade enrich sentence merry cactus drum example citizen choice tent');
 
       expect(actualMnemonic.mnemonicList, expectedMnemonic.mnemonicList);
     });
   });
 
-  group('Tests of Mnemonic.fromString() constructor', () {
-    test('Should [return Mnemonic] from given String', () {
+  group('Tests of Mnemonic.fromMnemonicPhrase() constructor', () {
+    test('Should [return Mnemonic] from given mnemonic phrase', () {
       // Arrange
       String actualMnemonicString = 'catalog letter frown ramp chest van pole unfold sound unable cool endorse';
 
       // Act
-      Mnemonic actualMnemonic = Mnemonic.fromString(actualMnemonicString);
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase(actualMnemonicString);
 
       // Assert
       Mnemonic expectedMnemonic =
-          const Mnemonic(<String>['catalog', 'letter', 'frown', 'ramp', 'chest', 'van', 'pole', 'unfold', 'sound', 'unable', 'cool', 'endorse']);
+          Mnemonic(const <String>['catalog', 'letter', 'frown', 'ramp', 'chest', 'van', 'pole', 'unfold', 'sound', 'unable', 'cool', 'endorse']);
 
       expect(actualMnemonic.mnemonicList, expectedMnemonic.mnemonicList);
     });
 
-    test('Should [return Mnemonic] from given String (custom delimiter)', () {
+    test('Should [return Mnemonic] from given mnemonic phrase (custom delimiter)', () {
       // Arrange
       String actualMnemonicString = 'catalogdeliletterdelifrowndelirampdelichestdelivandelipoledeliunfolddelisounddeliunabledelicooldeliendorse';
 
       // Act
-      Mnemonic actualMnemonic = Mnemonic.fromString(actualMnemonicString, delimiter: 'deli');
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase(actualMnemonicString, delimiter: 'deli');
 
       // Assert
       Mnemonic expectedMnemonic =
-          const Mnemonic(<String>['catalog', 'letter', 'frown', 'ramp', 'chest', 'van', 'pole', 'unfold', 'sound', 'unable', 'cool', 'endorse']);
+          Mnemonic(const <String>['catalog', 'letter', 'frown', 'ramp', 'chest', 'van', 'pole', 'unfold', 'sound', 'unable', 'cool', 'endorse']);
 
       expect(actualMnemonic.mnemonicList, expectedMnemonic.mnemonicList);
     });
-  });
 
-  group('Tests of Mnemonic.isValid getter', () {
-    test('Should [return TRUE] when mnemonic is valid', () {
-      // Arrange
-      Mnemonic actualMnemonic = Mnemonic.fromString('catalog letter frown ramp chest van pole unfold sound unable cool endorse');
-
-      // Act
-      bool actualIsValid = actualMnemonic.isValid;
-
+    test('Should [throw MnemonicException] (MnemonicExceptionType.invalidLength) if length of the mnemonic phrase is not divisible by 3', () {
       // Assert
-      expect(actualIsValid, true);
+      expect(
+        () => Mnemonic.fromMnemonicPhrase('catalog letter frown ramp chest van unfold sound unable cool endorse'),
+        throwsA(const MnemonicException(MnemonicExceptionType.invalidLength)),
+      );
     });
 
-    test('Should [return FALSE] when length of the mnemonic is not divisible by 3', () {
-      // Arrange
-      Mnemonic actualMnemonic = Mnemonic.fromString('catalog letter frown ramp chest van unfold sound unable cool endorse');
-
-      // Act
-      bool actualIsValid = actualMnemonic.isValid;
-
+    test('Should [throw MnemonicException] (MnemonicExceptionType.invalidWord) if mnemonic phrase contains words from outside the dictionary', () {
       // Assert
-      expect(actualIsValid, false);
+      expect(
+        () => Mnemonic.fromMnemonicPhrase('ammonium nitrite atom hydrogen cyanide carbonate chlorate chlorite perchlorate cation peroxide oxalate'),
+        throwsA(const MnemonicException(MnemonicExceptionType.invalidWord)),
+      );
     });
 
-    test('Should [return FALSE] when mnemonic contains a word from outside the dictionary', () {
-      // Arrange
-      Mnemonic actualMnemonic = Mnemonic.fromString('ammonium nitrite atom hydrogen cyanide carbonate chlorate chlorite perchlorate cation peroxide oxalate');
-
-      // Act
-      bool actualIsValid = actualMnemonic.isValid;
-
+    test('Should [throw MnemonicException] (MnemonicExceptionType.invalidChecksum) if mnemonic phrase has invalid checksum', () {
       // Assert
-      expect(actualIsValid, false);
-    });
-
-    test('Should [return FALSE] when mnemonic has invalid checksum', () {
-      // Arrange
-      Mnemonic actualMnemonic = Mnemonic.fromString('catalog letter frown ramp chest van pole unfold sound unable cool require');
-
-      // Act
-      bool actualIsValid = actualMnemonic.isValid;
-
-      // Assert
-      expect(actualIsValid, false);
+      expect(
+        () => Mnemonic.fromMnemonicPhrase('catalog letter frown ramp chest van pole unfold sound unable cool require'),
+        throwsA(const MnemonicException(MnemonicExceptionType.invalidChecksum)),
+      );
     });
   });
 
   group('Tests of Mnemonic.entropy getter', () {
     test('Should [return entropy] from [12-word Mnemonic]', () {
       // Arrange
-      Mnemonic actualMnemonic = Mnemonic.fromString('admit decide brave dinosaur patch fresh april toward elite clutch toy witness');
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase('admit decide brave dinosaur patch fresh april toward elite clutch toy witness');
 
       // Act
       Uint8List actualEntropy = actualMnemonic.entropy;
@@ -224,7 +240,7 @@ void main() {
 
     test('Should [return entropy] from [15-word Mnemonic]', () {
       // Arrange
-      Mnemonic actualMnemonic = Mnemonic.fromString('lake stumble pencil clog add scan resource attend huge space three salon hip shift drama');
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase('lake stumble pencil clog add scan resource attend huge space three salon hip shift drama');
 
       // Act
       Uint8List actualEntropy = actualMnemonic.entropy;
@@ -237,8 +253,8 @@ void main() {
 
     test('Should [return entropy] from [18-word Mnemonic]', () {
       // Arrange
-      Mnemonic actualMnemonic =
-          Mnemonic.fromString('very erosion proud virus remain pony dignity hat tornado art enhance enhance rabbit add hospital buffalo gallery journey');
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase(
+          'very erosion proud virus remain pony dignity hat tornado art enhance enhance rabbit add hospital buffalo gallery journey');
 
       // Act
       Uint8List actualEntropy = actualMnemonic.entropy;
@@ -251,7 +267,7 @@ void main() {
 
     test('Should [return entropy] from [21-word Mnemonic]', () {
       // Arrange
-      Mnemonic actualMnemonic = Mnemonic.fromString(
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase(
           'concert tired breeze call boy business chronic fox crater fire arctic universe void remember giraffe fetch hint select sound insect sister');
 
       // Act
@@ -265,7 +281,7 @@ void main() {
 
     test('Should [return entropy] from [24-word Mnemonic]', () {
       // Arrange
-      Mnemonic actualMnemonic = Mnemonic.fromString(
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase(
           'kiwi prosper empty sphere recall predict border bridge adult grid hunt confirm spread priority decade enrich sentence merry cactus drum example citizen choice tent');
 
       // Act
@@ -275,95 +291,6 @@ void main() {
       Uint8List expectedEntropy = base64Decode('e3WRJOi7N1NGcN4DzM29l30xVc4iWMPxdIAhxOZSig4=');
 
       expect(actualEntropy, expectedEntropy);
-    });
-
-    test('Should [throw Exception] if length of the mnemonic is not divisible by 3', () {
-      // Arrange
-      Mnemonic actualMnemonic = Mnemonic.fromString('catalog letter frown ramp chest van unfold sound unable cool endorse');
-
-      // Assert
-      expect(() => actualMnemonic.entropy, throwsA(isA<Exception>()));
-    });
-
-    test('Should [throw Exception] if mnemonic contains a word from outside the dictionary', () {
-      // Arrange
-      Mnemonic actualMnemonic = Mnemonic.fromString('ammonium nitrite atom hydrogen cyanide carbonate chlorate chlorite perchlorate cation peroxide oxalate');
-
-      // Assert
-      expect(() => actualMnemonic.entropy, throwsA(isA<Exception>()));
-    });
-
-    test('Should [throw Exception] if mnemonic has invalid checksum', () {
-      // Arrange
-      Mnemonic actualMnemonic = Mnemonic.fromString('catalog letter frown ramp chest van pole unfold sound unable cool require');
-
-      // Assert
-      expect(() => actualMnemonic.entropy, throwsA(isA<Exception>()));
-    });
-  });
-
-  group('Tests of Mnemonic.length getter', () {
-    test('Should [return 12] from [12-word Mnemonic]', () {
-      // Arrange
-      Mnemonic actualMnemonic = Mnemonic.fromString('admit decide brave dinosaur patch fresh april toward elite clutch toy witness');
-
-      // Act
-      int actualLength = actualMnemonic.length;
-
-      // Assert
-      int expectedLength = 12;
-      expect(actualLength, expectedLength);
-    });
-
-    test('Should [return 15] from [15-word Mnemonic]', () {
-      // Arrange
-      Mnemonic actualMnemonic = Mnemonic.fromString('lake stumble pencil clog add scan resource attend huge space three salon hip shift drama');
-
-      // Act
-      int actualLength = actualMnemonic.length;
-
-      // Assert
-      int expectedLength = 15;
-      expect(actualLength, expectedLength);
-    });
-
-    test('Should [return 18] from [18-word Mnemonic]', () {
-      // Arrange
-      Mnemonic actualMnemonic =
-          Mnemonic.fromString('very erosion proud virus remain pony dignity hat tornado art enhance enhance rabbit add hospital buffalo gallery journey');
-
-      // Act
-      int actualLength = actualMnemonic.length;
-
-      // Assert
-      int expectedLength = 18;
-      expect(actualLength, expectedLength);
-    });
-
-    test('Should [return 21] from [21-word Mnemonic]', () {
-      // Arrange
-      Mnemonic actualMnemonic = Mnemonic.fromString(
-          'concert tired breeze call boy business chronic fox crater fire arctic universe void remember giraffe fetch hint select sound insect sister');
-
-      // Act
-      int actualLength = actualMnemonic.length;
-
-      // Assert
-      int expectedLength = 21;
-      expect(actualLength, expectedLength);
-    });
-
-    test('Should [return 24] from [24-word Mnemonic]', () {
-      // Arrange
-      Mnemonic actualMnemonic = Mnemonic.fromString(
-          'kiwi prosper empty sphere recall predict border bridge adult grid hunt confirm spread priority decade enrich sentence merry cactus drum example citizen choice tent');
-
-      // Act
-      int actualLength = actualMnemonic.length;
-
-      // Assert
-      int expectedLength = 24;
-      expect(actualLength, expectedLength);
     });
   });
 }


### PR DESCRIPTION
This branch introduces custom exception messages thrown when constructing Mnemonic objects with an invalid mnemonic phrase. Previously, this class allowed to build an invalid mnemonic and check whether it's correct or not using a separate method. However, some of the use cases require additional information about the problems occurred during parsing.

List of changes:
- modified mnemonic.dart to throw custom exceptions for invalid mnemonic phrases while constructing Mnemonic objects
- created mnemonic_exception.dart, mnemonic_exception_type.dart to identify errors occurred during mnemonic phrase parsing
- renamed fromString() constructor in mnemonic.dart to fromMnemonicPhrase() in order to determine the exact value accepted by the constructor
- divided larger methods in mnemonic.dart into smaller ones to ensure code readability after mnemonic validation related changes