### PR TITLE
Refactor: Flutter dependencies removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # cryptography_utils
-Private keys manager
+Dart package containing utility methods for common cryptographic and blockchain-specific operations.
 
 ## Installation
 Use git clone to download [cryptography_utils](https://github.com/CandyLabsIT/cryptography_utils) project.
@@ -8,46 +8,25 @@ git clone git@github.com:CandyLabsIT/cryptography_utils.git
 ```
 
 ## Usage
-The project runs on flutter version **3.16.2**. You can use [fvm](https://fvm.app/docs/getting_started/installation)
-for easy switching between versions otherwise see [flutter installation](https://docs.flutter.dev/get-started/install)
+The project runs on Flutter version **3.16.2** (Dart >=3.1.4). You can use [fvm](https://fvm.app/docs/getting_started/installation)
+for easy switching between Dart/Flutter versions otherwise see [flutter installation](https://docs.flutter.dev/get-started/install)
 ```bash
 # Install and use required flutter version
 fvm install 3.16.2
-fvm use 3.16.2
+fvm use 3.16.2 --force
 
 # Install required packages in pubspec.yaml
-fvm flutter pub get
-
-# Run project
-fvm flutter run 
-```
-
-To generate config files use
-```bash
-fvm flutter pub run build_runner
-```
-```bash
-# Built-in Commands 
-# - build: Runs a single build and exits.
-# - watch: Runs a persistent build server that watches the files system for edits and does rebuilds as necessary
-# - serve: Same as watch, but runs a development server as well
-
-# Command Line Options
-# --delete-conflicting-outputs: Assume conflicting outputs in the users package are from previous builds, and skip the user prompt that would usually be provided.
-# 
-# Command example:
-
-fvm flutter pub run build_runner watch --delete-conflicting-outputs
+fvm dart pub get
 ```
 
 ## Tests
-To run Unit Tests / Integration tests
+To run tests
 ```bash
 # Run all Unit Tests
-fvm flutter test test
+fvm dart run test
 
 # To run specific Unit Test
-fvm flutter test path/to/test.dart
+fvm dart test absolute/path/to/test.dart
 ```
 
 ## Contributing

--- a/lib/src/bip/bip32/derivators/legacy_derivators/i_legacy_derivator.dart
+++ b/lib/src/bip/bip32/derivators/legacy_derivators/i_legacy_derivator.dart
@@ -1,7 +1,5 @@
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter/material.dart';
 
-@optionalTypeArgs
 abstract interface class ILegacyDerivator<T extends IBip32PrivateKey> implements IDerivator {
   Future<T> derivePath(Mnemonic mnemonic, LegacyDerivationPath legacyDerivationPath);
 

--- a/lib/src/bip/bip32/hd_wallet/legacy_hd_wallet.dart
+++ b/lib/src/bip/bip32/hd_wallet/legacy_hd_wallet.dart
@@ -17,7 +17,7 @@ class LegacyHDWallet extends AHDWallet {
   static Future<LegacyHDWallet> fromMnemonic({
     required String derivationPathString,
     required Mnemonic mnemonic,
-    required LegacyWalletConfig walletConfig,
+    required LegacyWalletConfig<IBip32PrivateKey> walletConfig,
   }) async {
     LegacyDerivationPath derivationPath = LegacyDerivationPath.parse(derivationPathString);
 

--- a/lib/src/bip/bip39/mnemonic.dart
+++ b/lib/src/bip/bip39/mnemonic.dart
@@ -1,8 +1,9 @@
+import 'dart:typed_data';
+
 import 'package:crypto/crypto.dart';
 import 'package:cryptography_utils/cryptography_utils.dart';
 
 import 'package:equatable/equatable.dart';
-import 'package:flutter/foundation.dart';
 
 /// The [Mnemonic] class is designed for handling mnemonic phrases, which are human-readable sequences of words used to generate and recover cryptographic keys.
 /// This functionality is typically used in the context of cryptocurrency wallets for generating private-keys in a way that is easier for users to record and remember.

--- a/lib/src/bip/bip39/mnemonic_seed_generator/a_mnemonic_seed_generator.dart
+++ b/lib/src/bip/bip39/mnemonic_seed_generator/a_mnemonic_seed_generator.dart
@@ -1,5 +1,7 @@
+import 'dart:typed_data';
+
+import 'package:compute/compute.dart';
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter/foundation.dart';
 
 /// Abstract class for mnemonic seed generators.
 /// Contains shared method to calculate seed from mnemonic in separated thread.
@@ -10,7 +12,6 @@ abstract class AMnemonicSeedGenerator {
 
   Future<Uint8List> generateSeed(Mnemonic mnemonic, {String passphrase = ''});
 
-  @protected
   Future<Uint8List> computeSeed({
     required Uint8List password,
     required Uint8List salt,

--- a/lib/src/bip/bip39/mnemonic_seed_generator/legacy_mnemonic_seed_generator.dart
+++ b/lib/src/bip/bip39/mnemonic_seed_generator/legacy_mnemonic_seed_generator.dart
@@ -1,5 +1,6 @@
+import 'dart:typed_data';
+
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter/foundation.dart';
 
 /// The [LegacyMnemonicSeedGenerator] class provides functionality to generate mnemonic seed using traditional method based on mnemonic phrase.
 /// It's used in various cryptographic applications like Bitcoin, Ethereum or Cosmos.

--- a/lib/src/wallet_config/bip44_wallets_config.dart
+++ b/lib/src/wallet_config/bip44_wallets_config.dart
@@ -8,7 +8,7 @@ import 'package:cryptography_utils/cryptography_utils.dart';
 ///   - `curveType`: Type of the elliptic curve used for key generation
 ///   - `purpose`: Type of the BIP proposal
 class Bip44WalletsConfig {
-  static LegacyWalletConfig bitcoin = LegacyWalletConfig(
+  static LegacyWalletConfig<Secp256k1PrivateKey> bitcoin = LegacyWalletConfig<Secp256k1PrivateKey>(
     addressEncoder: BitcoinP2PKHAddressEncoder(),
     derivator: Secp256k1Derivator(),
     coinIndex: Slip44.bitcoin,
@@ -16,7 +16,7 @@ class Bip44WalletsConfig {
     purpose: BipProposalType.bip44,
   );
 
-  static LegacyWalletConfig cosmos = LegacyWalletConfig(
+  static LegacyWalletConfig<Secp256k1PrivateKey> cosmos = LegacyWalletConfig<Secp256k1PrivateKey>(
     addressEncoder: CosmosAddressEncoder(hrp: Slip173.cosmos),
     derivator: Secp256k1Derivator(),
     coinIndex: Slip44.cosmos,
@@ -24,7 +24,7 @@ class Bip44WalletsConfig {
     purpose: BipProposalType.bip44,
   );
 
-  static LegacyWalletConfig ethereum = LegacyWalletConfig(
+  static LegacyWalletConfig<Secp256k1PrivateKey> ethereum = LegacyWalletConfig<Secp256k1PrivateKey>(
     addressEncoder: EthereumAddressEncoder(),
     derivator: Secp256k1Derivator(),
     coinIndex: Slip44.ethereum,
@@ -32,7 +32,7 @@ class Bip44WalletsConfig {
     purpose: BipProposalType.bip44,
   );
 
-  static LegacyWalletConfig kira = LegacyWalletConfig(
+  static LegacyWalletConfig<Secp256k1PrivateKey> kira = LegacyWalletConfig<Secp256k1PrivateKey>(
     addressEncoder: CosmosAddressEncoder(hrp: Slip173.kira),
     derivator: Secp256k1Derivator(),
     coinIndex: Slip44.kira,

--- a/lib/src/wallet_config/bip49_wallets_config.dart
+++ b/lib/src/wallet_config/bip49_wallets_config.dart
@@ -8,7 +8,7 @@ import 'package:cryptography_utils/cryptography_utils.dart';
 ///   - `curveType`: Type of the elliptic curve used for key generation
 ///   - `purpose`: Type of the BIP proposal
 class Bip49WalletsConfig {
-  static LegacyWalletConfig bitcoin = LegacyWalletConfig(
+  static LegacyWalletConfig<Secp256k1PrivateKey> bitcoin = LegacyWalletConfig<Secp256k1PrivateKey>(
     addressEncoder: BitcoinP2SHAddressEncoder(),
     derivator: Secp256k1Derivator(),
     coinIndex: Slip44.bitcoin,

--- a/lib/src/wallet_config/bip84_wallets_config.dart
+++ b/lib/src/wallet_config/bip84_wallets_config.dart
@@ -8,7 +8,7 @@ import 'package:cryptography_utils/cryptography_utils.dart';
 ///   - `curveType`: Type of the elliptic curve used for key generation
 ///   - `purpose`: Type of the BIP proposal
 class Bip84WalletsConfig {
-  static LegacyWalletConfig bitcoin = LegacyWalletConfig(
+  static LegacyWalletConfig<Secp256k1PrivateKey> bitcoin = LegacyWalletConfig<Secp256k1PrivateKey>(
     addressEncoder: BitcoinP2WPKHAddressEncoder(hrp: Slip173.bitcoin),
     derivator: Secp256k1Derivator(),
     coinIndex: Slip44.bitcoin,

--- a/lib/src/wallet_config/config_types/legacy_wallet_config.dart
+++ b/lib/src/wallet_config/config_types/legacy_wallet_config.dart
@@ -1,12 +1,12 @@
 import 'package:cryptography_utils/cryptography_utils.dart';
 
-class LegacyWalletConfig extends AWalletConfig {
+class LegacyWalletConfig<T extends IBip32PrivateKey> extends AWalletConfig {
   final int coinIndex;
   final CurveType curveType;
   final BipProposalType purpose;
 
   const LegacyWalletConfig({
-    required ILegacyDerivator derivator,
+    required ILegacyDerivator<T> derivator,
     required super.addressEncoder,
     required this.coinIndex,
     required this.curveType,
@@ -14,7 +14,7 @@ class LegacyWalletConfig extends AWalletConfig {
   }) : super(derivator: derivator);
 
   @override
-  ILegacyDerivator get derivator => super.derivator as ILegacyDerivator;
+  ILegacyDerivator<T> get derivator => super.derivator as ILegacyDerivator<T>;
 
   String get baseDerivationPath => "m/${purpose.proposalNumber}'/$coinIndex'";
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,33 +1,30 @@
 name: cryptography_utils
 description: "Cryptography utils"
-version: 0.0.7
+version: 0.0.8
 
 environment:
-  sdk: ">=3.2.2"
-  flutter: "^3.16.2"
+  sdk: ">=3.1.4"
 
 dependencies:
-  flutter:
-    sdk: flutter
-
   # A Dart package that helps to implement value based equality without needing to explicitly override == and hashCode.
   # https://pub.dev/packages/equatable
-  equatable: ^2.0.5
+  equatable: 2.0.5
 
   # Implementations of SHA, MD5, and HMAC cryptographic functions.
   # https://pub.dev/packages/crypto
-  crypto: ^3.0.3
+  crypto: 3.0.3
 
   # Library implementing Bitcoins BIP173 (Bech32 encoding) specification in a Flutter friendly fashion.
   # https://pub.dev/packages/bech32
-  bech32: ^0.2.2
+  bech32: 0.2.2
 
   # A Dart library implementing cryptographic algorithms and primitives, modeled on the BouncyCastle library.
   # https://pub.dev/packages/pointycastle
-  pointycastle: ^3.7.4
+  pointycastle: 3.7.4
+
+  # Flutter's compute function made available for all non-Flutter Dart programs
+  # https://pub.dev/packages/compute
+  compute: 1.0.2
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
-
-flutter:
+  test: 1.25.5

--- a/test/bip/bip32/derivation_path/legacy_derivation_path/legacy_derivation_path_element_test.dart
+++ b/test/bip/bip32/derivation_path/legacy_derivation_path/legacy_derivation_path_element_test.dart
@@ -1,5 +1,5 @@
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of LegacyDerivationPathElement.parse() constructor', () {

--- a/test/bip/bip32/derivation_path/legacy_derivation_path/legacy_derivation_path_test.dart
+++ b/test/bip/bip32/derivation_path/legacy_derivation_path/legacy_derivation_path_test.dart
@@ -1,5 +1,5 @@
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of LegacyDerivationPath.parse() constructor', () {

--- a/test/bip/bip32/derivators/legacy_derivators/secp256k1_derivator_test.dart
+++ b/test/bip/bip32/derivators/legacy_derivators/secp256k1_derivator_test.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   Secp256k1Derivator actualSecp256k1Derivator = Secp256k1Derivator();

--- a/test/bip/bip32/hd_wallet/legacy_hd_wallet_test.dart
+++ b/test/bip/bip32/hd_wallet/legacy_hd_wallet_test.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   Mnemonic mnemonic = Mnemonic.fromMnemonicPhrase(

--- a/test/bip/bip39/mnemonic_seed_generator/entropy_mnemonic_seed_generator_test.dart
+++ b/test/bip/bip39/mnemonic_seed_generator/entropy_mnemonic_seed_generator_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of EntropyMnemonicSeedGenerator.generateSeed()', () {

--- a/test/bip/bip39/mnemonic_seed_generator/legacy_mnemonic_seed_generator_test.dart
+++ b/test/bip/bip39/mnemonic_seed_generator/legacy_mnemonic_seed_generator_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of LegacyMnemonicSeedGenerator.generateSeed()', () {

--- a/test/bip/bip39/mnemonic_size_test.dart
+++ b/test/bip/bip39/mnemonic_size_test.dart
@@ -1,5 +1,5 @@
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of MnemonicSize.entropyBytesSize getter', () {

--- a/test/bip/bip39/mnemonic_test.dart
+++ b/test/bip/bip39/mnemonic_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of Mnemonic() constructor', () {

--- a/test/cdsa/ecdsa/ec_curve_test.dart
+++ b/test/cdsa/ecdsa/ec_curve_test.dart
@@ -1,5 +1,5 @@
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of ECCurve.baselen getter', () {

--- a/test/cdsa/ecdsa/ec_point_test.dart
+++ b/test/cdsa/ecdsa/ec_point_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   ECCurve actualECCurve = ECCurve(

--- a/test/cdsa/ecdsa/ec_private_key_test.dart
+++ b/test/cdsa/ecdsa/ec_private_key_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of ECPrivateKey.fromBytes() constructor', () {

--- a/test/cdsa/ecdsa/ec_public_key_test.dart
+++ b/test/cdsa/ecdsa/ec_public_key_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of ECPublicKey.compressed getter', () {

--- a/test/cdsa/ecdsa/secp256k1/secp256k1_private_key_test.dart
+++ b/test/cdsa/ecdsa/secp256k1/secp256k1_private_key_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of Secp256k1PrivateKey.bytes getter', () {

--- a/test/cdsa/ecdsa/secp256k1/secp256k1_public_key_test.dart
+++ b/test/cdsa/ecdsa/secp256k1/secp256k1_public_key_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of Secp256k1PublicKey.compressed getter', () {

--- a/test/cdsa/ecdsa/signer/ec_signature_test.dart
+++ b/test/cdsa/ecdsa/signer/ec_signature_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of ECSignature.fromBase64() constructor', () {

--- a/test/cdsa/ecdsa/signer/ecdsa_signer_test.dart
+++ b/test/cdsa/ecdsa/signer/ecdsa_signer_test.dart
@@ -2,7 +2,7 @@ import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of ECDSASigner.sign()', () {

--- a/test/cdsa/ecdsa/signer/rfc6979_test.dart
+++ b/test/cdsa/ecdsa/signer/rfc6979_test.dart
@@ -1,6 +1,6 @@
 import 'package:crypto/crypto.dart';
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of RFC6979.generateNextK()', () {

--- a/test/encoder/address_encoder/bitcoin/bitcoin_p2pkh_address_encoder_test.dart
+++ b/test/encoder/address_encoder/bitcoin/bitcoin_p2pkh_address_encoder_test.dart
@@ -1,5 +1,5 @@
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   ECPoint actualPointQ = ECPoint(

--- a/test/encoder/address_encoder/bitcoin/bitcoin_p2sh_address_encoder_test.dart
+++ b/test/encoder/address_encoder/bitcoin/bitcoin_p2sh_address_encoder_test.dart
@@ -1,5 +1,5 @@
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   ECPoint actualPointQ = ECPoint(

--- a/test/encoder/address_encoder/bitcoin/bitcoin_p2wpkh_address_encoder_test.dart
+++ b/test/encoder/address_encoder/bitcoin/bitcoin_p2wpkh_address_encoder_test.dart
@@ -1,5 +1,5 @@
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   ECPoint actualPointQ = ECPoint(

--- a/test/encoder/address_encoder/cosmos_address_encoder_test.dart
+++ b/test/encoder/address_encoder/cosmos_address_encoder_test.dart
@@ -1,5 +1,5 @@
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   ECPoint actualPointQ = ECPoint(

--- a/test/encoder/address_encoder/ethereum_address_encoder_test.dart
+++ b/test/encoder/address_encoder/ethereum_address_encoder_test.dart
@@ -1,5 +1,5 @@
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   ECPoint actualPointQ = ECPoint(

--- a/test/encoder/generic_encoder/base/base58_encoder_test.dart
+++ b/test/encoder/generic_encoder/base/base58_encoder_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of Base58Encoder.encode()', () {

--- a/test/encoder/generic_encoder/bech32/bech32_encoder_test.dart
+++ b/test/encoder/generic_encoder/bech32/bech32_encoder_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of Bech32Encoder.encode()', () {

--- a/test/encoder/generic_encoder/bech32/segwit_bech32_encoder_test.dart
+++ b/test/encoder/generic_encoder/bech32/segwit_bech32_encoder_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of SegwitBech32Encoder.encode()', () {

--- a/test/encoder/generic_encoder/hex_encoder_test.dart
+++ b/test/encoder/generic_encoder/hex_encoder_test.dart
@@ -1,7 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   Uint8List asciiCodeBytes = Uint8List.fromList('123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~'.codeUnits);

--- a/test/hash/hmac_test.dart
+++ b/test/hash/hmac_test.dart
@@ -3,7 +3,7 @@ import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of HMAC.process()', () {

--- a/test/hash/keccak_test.dart
+++ b/test/hash/keccak_test.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   Uint8List actualDataToHash = Uint8List.fromList('123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~'.codeUnits);

--- a/test/hash/pbkdf2_test.dart
+++ b/test/hash/pbkdf2_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of PBKDF2.process()', () {

--- a/test/hash/ripemd160_test.dart
+++ b/test/hash/ripemd160_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   Uint8List actualDataToHash = Uint8List.fromList('123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~'.codeUnits);

--- a/test/utils/bigint_utils_test.dart
+++ b/test/utils/bigint_utils_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of BigIntUtils.changeToBytes()', () {

--- a/test/utils/binary_utils_test.dart
+++ b/test/utils/binary_utils_test.dart
@@ -1,5 +1,5 @@
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of BinaryUtils.binaryToInt()', () {

--- a/test/utils/bytes_utils_test.dart
+++ b/test/utils/bytes_utils_test.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of BytesUtils.changeToOctetsWithOrderPadding()', () {

--- a/test/utils/ec_point_utils_test.dart
+++ b/test/utils/ec_point_utils_test.dart
@@ -1,5 +1,5 @@
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   ECCurve actualECCurve = ECCurve(

--- a/test/utils/secure_random_test.dart
+++ b/test/utils/secure_random_test.dart
@@ -1,7 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Tests of SecureRandom.getBytes()', () {


### PR DESCRIPTION
Previously, the cryptography_utils package had Flutter in its dependencies. Because of this, only Flutter projects could use this package, and consequently, Dart command line applications were not supported. Since Flutter is not necessary for using cryptography_utils, it was decided to remove it from the dependencies to enable testing without the need to use the Flutter framework.

List of changes:
- removed Flutter dependencies from pubspec.yaml
- removed ranged constraints from the packages version in pubspec.yaml to guarantee the use of their tested and verified version
- updated supported Dart version from ">=3.3.2" to ">=3.1.4" to allow projects using older Dart version to use cryptography_utils
- replaced "flutter_test" import into "test" in all tests
- removed Flutter-specific annotations like @optionalTypeArgs, @protected
- replaced compute() method usages with method from external package. Native dart language supports multithreading, but doesn't have predefined methods simplifying those operations.
- updated README.md to include information about Dart compatibility