### PR TITLE
Bugfix: RLP - encodeLength()

### DIFF
--- a/lib/src/encoder/generic_encoder/hex_encoder.dart
+++ b/lib/src/encoder/generic_encoder/hex_encoder.dart
@@ -20,6 +20,10 @@ class HexEncoder {
     if (hex.startsWith('0x')) {
       tmpHex = hex.substring(2);
     }
+    if (tmpHex.length % 2 != 0) {
+      tmpHex = '0$tmpHex';
+    }
+
     List<String> hexString = tmpHex.split('');
     List<String> hexPairs = <String>[];
 

--- a/lib/src/encoder/generic_encoder/rlp/rlp_utils.dart
+++ b/lib/src/encoder/generic_encoder/rlp/rlp_utils.dart
@@ -1,7 +1,24 @@
-// Class was shaped by the influence of JavaScript key sources including:
-// https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/rlp
+// Class was shaped by the influence of several key sources including:
+// "rlp" Copyright (c) 2018 Max Holman <max@holmn.com>
+// https://github.com/maxholman/rlp/
 //
-// Mozilla Public License Version 2.0
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 part of 'rlp_coder.dart';
 
 /// A utility class providing static methods related to the Recursive Length Prefix (RLP) encoding.
@@ -12,10 +29,17 @@ class RLPUtils {
   static Uint8List encodeLength(int length, int offset) {
     if (length < 56) {
       return Uint8List.fromList(<int>[length + offset]);
+    } else {
+      Uint8List binaryLength = _convertLengthToBytes(length);
+      return Uint8List.fromList(<int>[binaryLength.length + offset + 55, ...binaryLength]);
     }
-    String lengthHex = length.toRadixString(16).padLeft(2, '0');
-    int lengthOfLength = lengthHex.length ~/ 2;
-    String firstByte = (offset + 55 + lengthOfLength).toRadixString(16).padLeft(2, '0');
-    return Uint8List.fromList(HexEncoder.decode('$firstByte$lengthHex'));
+  }
+
+  /// Converts the specified length to a list of bytes.
+  static Uint8List _convertLengthToBytes(int length) {
+    if (length == 0) {
+      return Uint8List(0);
+    }
+    return Uint8List.fromList(<int>[..._convertLengthToBytes(length ~/ 256), (length % 256)]);
   }
 }

--- a/lib/src/encoder/generic_encoder/rlp/types/rlp_bytes.dart
+++ b/lib/src/encoder/generic_encoder/rlp/types/rlp_bytes.dart
@@ -18,6 +18,9 @@ class RLPBytes extends Equatable implements IRLPElement {
   /// Constructs an [RLPBytes] instance from HEX data.
   RLPBytes.fromHex(String value) : data = HexEncoder.decode(value);
 
+  /// Constructs an empty [RLPBytes] instance
+  RLPBytes.empty() : data = Uint8List(0);
+
   /// Encodes the byte array into RLP format. If the data is a single byte less than "0x80", it returns the data directly.
   /// Otherwise, it prepends the length of the data to the data itself, adjusting for RLP encoding requirements.
   @override

--- a/lib/src/transactions/ethereum/ethereum_eip1559_transaction.dart
+++ b/lib/src/transactions/ethereum/ethereum_eip1559_transaction.dart
@@ -106,6 +106,32 @@ class EthereumEIP1559Transaction extends Equatable implements IEthereumTransacti
     );
   }
 
+  EthereumEIP1559Transaction copyWith({
+    BigInt? chainId,
+    BigInt? nonce,
+    BigInt? maxPriorityFeePerGas,
+    BigInt? maxFeePerGas,
+    BigInt? gasLimit,
+    String? to,
+    BigInt? value,
+    Uint8List? data,
+    List<AccessListBytesItem>? accessList,
+    EthereumSignature? signature,
+  }) {
+    return EthereumEIP1559Transaction(
+      chainId: chainId ?? this.chainId,
+      nonce: nonce ?? this.nonce,
+      maxPriorityFeePerGas: maxPriorityFeePerGas ?? this.maxPriorityFeePerGas,
+      maxFeePerGas: maxFeePerGas ?? this.maxFeePerGas,
+      gasLimit: gasLimit ?? this.gasLimit,
+      to: to ?? this.to,
+      value: value ?? this.value,
+      data: data ?? this.data,
+      accessList: accessList ?? this.accessList,
+      signature: signature ?? this.signature,
+    );
+  }
+
   /// Serializes the transaction into a byte array.
   @override
   Uint8List serialize() {
@@ -123,7 +149,7 @@ class EthereumEIP1559Transaction extends Equatable implements IEthereumTransacti
       RLPBytes.fromBigInt(maxFeePerGas),
       RLPBytes.fromBigInt(gasLimit),
       RLPBytes.fromHex(to),
-      RLPBytes.fromBigInt(value),
+      if (value == BigInt.zero) RLPBytes.empty() else RLPBytes.fromBigInt(value),
       RLPBytes(data),
       RLPList(accessList.map((AccessListBytesItem e) => e.toRLP()).toList()),
     ];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cryptography_utils
 description: "Cryptography utils"
-version: 0.0.10
+version: 0.0.11
 
 environment:
   sdk: ">=3.1.4"

--- a/test/encoder/generic_encoder/rlp/rlp_utils_test.dart
+++ b/test/encoder/generic_encoder/rlp/rlp_utils_test.dart
@@ -32,5 +32,19 @@ void main() {
 
       expect(actualEncodedLength, expectedEncodedLength);
     });
+
+    test('Should [return encoded length] for [length >= 256]', () {
+      // Arrange
+      int actualLength = 257;
+      int actualOffset = 128;
+
+      // Act
+      Uint8List actualEncodedLength = RLPUtils.encodeLength(actualLength, actualOffset);
+
+      // Assert
+      Uint8List expectedEncodedLength = Uint8List.fromList(<int>[185, 1, 1]);
+
+      expect(actualEncodedLength, expectedEncodedLength);
+    });
   });
 }


### PR DESCRIPTION
This branch introduces a fix for encoding the length of byte arrays in the RLP algorithm for sequences larger than 256 bytes. The RLP algorithm has different variants for encoding byte lengths for lengths <56 bytes and >=56 bytes. However, the second variant implementation could only handle lists shorter than 256 bytes, which prevented signing certain transactions.

List of changes:
- modified encodeLength() method in rlp_utils.dart, to correctly encode all list lengths
- modified hex_encoder.dart by adding leading zero autofill. Some of the received transactions contain hexadecimal string without a leading zero, which was not supported by the decoder.
- modified the _toRLP() method in ethereum_eip1559_transaction.dart to represent a zero integer value as an empty list, as this is its correct representation
- added RLPBytes.empty() constructor to rlp_bytes.dart to simplify creating an empty list in RLP encoding
- added copyWith() method in ethereum_eip1559_transaction.dart to simplify the completion of partially received transaction packets