### PR TITLE
Feature: Migration to Flutter 3.16.9

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.16.2",
+  "flutterSdkVersion": "3.16.9",
   "flavors": {}
 }

--- a/README.md
+++ b/README.md
@@ -1,26 +1,35 @@
 # cryptography_utils
+
 Dart package containing utility methods for common cryptographic and blockchain-specific operations.
 
 ## Installation
-Use git clone to download [cryptography_utils](https://github.com/CandyLabsIT/cryptography_utils) project.
+
+Use git clone to download [cryptography_utils](https://github.com/snggle/cryptography_utils) project.
+
 ```bash
-git clone git@github.com:CandyLabsIT/cryptography_utils.git
+git clone git@github.com:snggle/cryptography_utils.git
 ```
 
 ## Usage
-The project runs on Flutter version **3.16.2** (Dart >=3.1.4). You can use [fvm](https://fvm.app/docs/getting_started/installation)
-for easy switching between Dart/Flutter versions otherwise see [flutter installation](https://docs.flutter.dev/get-started/install)
+
+The project runs on Dart version **3.2.6**. You can
+use [fvm](https://fvm.app/documentation/getting-started/installation)
+for easy switching between Dart/Flutter versions otherwise
+see [flutter installation](https://docs.flutter.dev/get-started/install)
+
 ```bash
 # Install and use required flutter version
-fvm install 3.16.2
-fvm use 3.16.2 --force
+fvm install 3.16.9
+fvm use 3.16.9 --force
 
 # Install required packages in pubspec.yaml
 fvm dart pub get
 ```
 
 ## Tests
+
 To run tests
+
 ```bash
 # Run all Unit Tests
 fvm dart run test
@@ -30,4 +39,6 @@ fvm dart test absolute/path/to/test.dart
 ```
 
 ## Contributing
-Pull requests are welcomed. For major changes, please open an issue first, to enable a discussion on what you would like to improve. Please make sure to provide and update tests as well. 
+
+Pull requests are welcomed. For major changes, please open an issue first, to enable a discussion on what you would like
+to improve. Please make sure to provide and update tests as well. 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,9 @@
 name: cryptography_utils
-description: "Cryptography utils"
-version: 0.0.13
+description: "Dart package containing utility methods for common cryptographic and blockchain-specific operations"
+version: 0.0.14
 
 environment:
-  sdk: ">=3.1.4"
+  sdk: ">=3.2.6"
 
 dependencies:
   # A Dart package that helps to implement value based equality without needing to explicitly override == and hashCode.
@@ -20,7 +20,7 @@ dependencies:
 
   # A Dart library implementing cryptographic algorithms and primitives, modeled on the BouncyCastle library.
   # https://pub.dev/packages/pointycastle
-  pointycastle: 3.7.4
+  pointycastle: 3.9.1
 
   # Flutter's compute function made available for all non-Flutter Dart programs
   # https://pub.dev/packages/compute
@@ -31,4 +31,6 @@ dependencies:
   decimal: 2.3.3
 
 dev_dependencies:
+  # A full featured library for writing and running Dart tests across platforms.
+  # https://pub.dev/packages/test
   test: 1.25.5


### PR DESCRIPTION
This branch introduces Flutter version upgrade from "3.16.2" (Dart 3.2.2) to "3.16.9" (Dart 3.2.6). This change was made to unify the version of Flutter/Dart used between projects.

List of changes:
- upgraded Flutter version from "3.16.2" (Dart 3.2.2) to "3.16.9" (Dart 3.2.6)
- upgraded packages version to the highest versions compatible with Flutter 3.16.9
- updated deprecated links and information about used Flutter version and in README.md