### PR TITLE
Feature: Secp256k1 keys construction

### DIFF
--- a/lib/src/bip/bip32/bip32_key_metadata.dart
+++ b/lib/src/bip/bip32/bip32_key_metadata.dart
@@ -6,34 +6,74 @@ import 'package:equatable/equatable.dart';
 /// Represents the metadata associated with a key in a BIP-32 hierarchical deterministic wallet.
 /// This class holds the necessary components used in the derivation of child keys within an HD wallet structure.
 class Bip32KeyMetadata extends Equatable {
-  /// The number of derivations from the master root key to this key, indicating its level in the hierarchy.
-  final int depth;
-
-  /// A 256-bit (32 bytes) value acting as a component of BIP-32 private key.
-  /// It's used in conjunction with [ECPrivateKey] or [ECPublicKey] for generating child private keys.
-  final Uint8List chainCode;
-
   /// The unique identifier derived from the hash of the ECDSA public key, representing this key in the hierarchy.
   final BigInt fingerprint;
 
+  /// The number of derivations from the master root key to this key, indicating its level in the hierarchy.
+  final int? depth;
+
+  /// A 256-bit (32 bytes) value acting as a component of BIP-32 private key.
+  /// It's used in conjunction with [ECPrivateKey] or [ECPublicKey] for generating child private keys.
+  final Uint8List? chainCode;
+
   /// The unique identifier for this key's direct parent, derived same way as [fingerprint].
-  final BigInt parentFingerprint;
+  final BigInt? parentFingerprint;
 
   /// The identifier for the root from which all keys in this hierarchy are derived.
-  final BigInt masterFingerprint;
+  final BigInt? masterFingerprint;
 
   /// The derivation path index in its shifted form. Is null for the master key.
   final int? shiftedIndex;
 
   /// Creates a new instance of [Bip32KeyMetadata] with the specified parameters.
   const Bip32KeyMetadata({
-    required this.depth,
-    required this.chainCode,
     required this.fingerprint,
-    required this.parentFingerprint,
-    required this.masterFingerprint,
+    this.depth,
+    this.chainCode,
+    this.parentFingerprint,
+    this.masterFingerprint,
     this.shiftedIndex,
   });
+
+  factory Bip32KeyMetadata.fromCompressedPublicKey({
+    required Uint8List compressedPublicKey,
+    int? depth,
+    Uint8List? chainCode,
+    BigInt? parentFingerprint,
+    BigInt? masterFingerprint,
+    int? shiftedIndex,
+  }) {
+    BigInt fingerprint = ABip32PublicKey.calcFingerprint(compressedPublicKey);
+
+    return Bip32KeyMetadata(
+      fingerprint: fingerprint,
+      depth: depth,
+      chainCode: chainCode,
+      parentFingerprint: parentFingerprint,
+      masterFingerprint: masterFingerprint,
+      shiftedIndex: shiftedIndex,
+    );
+  }
+
+  Bip32KeyMetadata deriveNext({
+    required Uint8List newCompressedPublicKey,
+    required Uint8List newChainCode,
+    required int newShiftedIndex,
+  }) {
+    BigInt newParentFingerprint = fingerprint;
+    BigInt newFingerprint = ABip32PublicKey.calcFingerprint(newCompressedPublicKey);
+
+    return Bip32KeyMetadata(
+      depth: depth != null ? depth! + 1 : null,
+      chainCode: newChainCode,
+      fingerprint: newFingerprint,
+      parentFingerprint: newParentFingerprint,
+      masterFingerprint: masterFingerprint,
+      shiftedIndex: newShiftedIndex,
+    );
+  }
+
+  bool get canBuildExtendedKey => depth != null && parentFingerprint != null && chainCode != null && shiftedIndex != null;
 
   @override
   List<Object?> get props => <Object?>[depth, chainCode, fingerprint, parentFingerprint, masterFingerprint, shiftedIndex];

--- a/lib/src/bip/bip32/hd_wallet/legacy_hd_wallet.dart
+++ b/lib/src/bip/bip32/hd_wallet/legacy_hd_wallet.dart
@@ -15,11 +15,25 @@ class LegacyHDWallet extends AHDWallet {
 
   /// Creates a new [LegacyHDWallet] from a mnemonic and a derivation path.
   static Future<LegacyHDWallet> fromMnemonic({
-    required LegacyDerivationPath derivationPath,
     required Mnemonic mnemonic,
+    required LegacyDerivationPath derivationPath,
     required LegacyWalletConfig<ABip32PrivateKey> walletConfig,
   }) async {
     ABip32PrivateKey bip32PrivateKey = await walletConfig.derivator.derivePath(mnemonic, derivationPath);
+    return LegacyHDWallet.fromPrivateKey(
+      privateKey: bip32PrivateKey,
+      derivationPath: derivationPath,
+      walletConfig: walletConfig,
+    );
+  }
+
+  /// Creates a new [LegacyHDWallet] from a mnemonic and a derivation path.
+  static LegacyHDWallet fromPrivateKey({
+    required ABip32PrivateKey privateKey,
+    required LegacyDerivationPath derivationPath,
+    required LegacyWalletConfig<ABip32PrivateKey> walletConfig,
+  }) {
+    ABip32PrivateKey bip32PrivateKey = privateKey;
     ABip32PublicKey bip32PublicKey = bip32PrivateKey.publicKey;
 
     String address = walletConfig.addressEncoder.encodePublicKey(bip32PublicKey);

--- a/lib/src/bip/bip32/keys/a_bip32_private_key.dart
+++ b/lib/src/bip/bip32/keys/a_bip32_private_key.dart
@@ -4,6 +4,24 @@ import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:equatable/equatable.dart';
 
 abstract class ABip32PrivateKey extends Equatable {
+  /// Value sizes for Extended private key (xprv).
+  /// Extended private key contains 78 bytes, which are divided into 6 parts.
+  static const int _xprvPrefixSize = 4;
+  static const int _xprvDepthSize = 1;
+  static const int _xprvParentFingerprintSize = 4;
+  static const int _xprvShiftedIndexSize = 4;
+  static const int _xprvChainCodeSize = 32;
+  static const int _xprvPrivateKeySize = 33;
+
+  static const List<int> xprvChunkSizes = <int>[
+    _xprvPrefixSize,
+    _xprvDepthSize,
+    _xprvParentFingerprintSize,
+    _xprvShiftedIndexSize,
+    _xprvChainCodeSize,
+    _xprvPrivateKeySize,
+  ];
+
   final Bip32KeyMetadata metadata;
 
   const ABip32PrivateKey({
@@ -11,12 +29,16 @@ abstract class ABip32PrivateKey extends Equatable {
   });
 
   String getExtendedPrivateKey([Uint8List? keyNetVerBytes]) {
+    if (metadata.canBuildExtendedKey == false) {
+      throw AssertionError('Cannot generate extended public key without metadata');
+    }
+
     Uint8List serializedPrivateKey = Uint8List.fromList(<int>[
       ...keyNetVerBytes ?? Bip32NetworkVersion.mainnet.private,
-      ...BigIntUtils.changeToBytes(BigInt.from(metadata.depth), length: 1),
-      ...BigIntUtils.changeToBytes(metadata.parentFingerprint),
+      metadata.depth!,
+      ...BigIntUtils.changeToBytes(metadata.parentFingerprint!, length: _xprvParentFingerprintSize),
       ...LegacyDerivationPathElement.fromShiftedIndex(metadata.shiftedIndex ?? 0).toBytes(),
-      ...metadata.chainCode,
+      ...metadata.chainCode!,
       ...<int>[0x00, ...bytes],
     ]);
 

--- a/lib/src/bip/bip32/keys/a_bip32_public_key.dart
+++ b/lib/src/bip/bip32/keys/a_bip32_public_key.dart
@@ -1,27 +1,58 @@
 import 'dart:typed_data';
 
+import 'package:crypto/crypto.dart';
 import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:equatable/equatable.dart';
 
 abstract class ABip32PublicKey extends Equatable {
+  /// Value sizes for Extended public key (xpub).
+  /// Extended private key contains 78 bytes, which are divided into 6 parts.
+  static const int _xpubPrefixSize = 4;
+  static const int _xpubDepthSize = 1;
+  static const int _xpubParentFingerprintSize = 4;
+  static const int _xpubShiftedIndexSize = 4;
+  static const int _xpubChainCodeSize = 32;
+  static const int _xpubPublicKeySize = 33;
+
+  static const List<int> xpubChunkSizes = <int>[
+    _xpubPrefixSize,
+    _xpubDepthSize,
+    _xpubParentFingerprintSize,
+    _xpubShiftedIndexSize,
+    _xpubChainCodeSize,
+    _xpubPublicKeySize,
+  ];
+
   final Bip32KeyMetadata metadata;
 
   const ABip32PublicKey({
     required this.metadata,
   });
 
+  static BigInt calcFingerprint(Uint8List publicKeyBytes) {
+    Uint8List sha256Fingerprint = Uint8List.fromList(sha256.convert(publicKeyBytes).bytes);
+    Uint8List ripemd160Fingerprint = Uint8List.fromList(Ripemd160().process(sha256Fingerprint));
+    return BigIntUtils.decode(ripemd160Fingerprint.sublist(0, 4));
+  }
+
   String getExtendedPublicKey([Uint8List? keyNetVerBytes]) {
+    if (metadata.canBuildExtendedKey == false) {
+      throw AssertionError('Cannot generate extended public key without metadata');
+    }
+
     Uint8List serializedPublicKey = Uint8List.fromList(<int>[
       ...keyNetVerBytes ?? Bip32NetworkVersion.mainnet.public,
-      ...BigIntUtils.changeToBytes(BigInt.from(metadata.depth), length: 1),
-      ...BigIntUtils.changeToBytes(metadata.parentFingerprint),
+      metadata.depth!,
+      ...BigIntUtils.changeToBytes(metadata.parentFingerprint!, length: _xpubParentFingerprintSize),
       ...LegacyDerivationPathElement.fromShiftedIndex(metadata.shiftedIndex ?? 0).toBytes(),
-      ...metadata.chainCode,
-      ...bytes
+      ...metadata.chainCode!,
+      ...compressed
     ]);
 
     return Base58Encoder.encodeWithChecksum(serializedPublicKey);
   }
 
-  Uint8List get bytes;
+  Uint8List get compressed;
+
+  Uint8List get uncompressed;
 }

--- a/lib/src/cdsa/ecdsa/ec_public_key.dart
+++ b/lib/src/cdsa/ecdsa/ec_public_key.dart
@@ -14,6 +14,16 @@ class ECPublicKey extends Equatable {
 
   const ECPublicKey(this.G, this.Q);
 
+  factory ECPublicKey.fromCompressedBytes(List<int> bytes, ECPoint G) {
+    ECPoint Q = ECPoint.fromCompressedBytes(bytes, G);
+    return ECPublicKey(G, Q);
+  }
+
+  factory ECPublicKey.fromUncompressedBytes(List<int> bytes, ECPoint G) {
+    ECPoint Q = ECPoint.fromUncompressedBytes(bytes.sublist(1), G);
+    return ECPublicKey(G, Q);
+  }
+
   Uint8List get compressed {
     return Q.toBytes(compressedBool: true);
   }

--- a/lib/src/cdsa/ecdsa/secp256k1/secp256k1_private_key.dart
+++ b/lib/src/cdsa/ecdsa/secp256k1/secp256k1_private_key.dart
@@ -8,9 +8,39 @@ class Secp256k1PrivateKey extends ABip32PrivateKey {
   final ECPrivateKey ecPrivateKey;
 
   const Secp256k1PrivateKey({
-    required super.metadata,
     required this.ecPrivateKey,
+    required super.metadata,
   });
+
+  factory Secp256k1PrivateKey.fromBytes(Uint8List bytes, {Bip32KeyMetadata? metadata}) {
+    ECPrivateKey ecPrivateKey = ECPrivateKey.fromBytes(bytes, CurvePoints.generatorSecp256k1);
+    Bip32KeyMetadata updatedMetadata = metadata ?? Bip32KeyMetadata.fromCompressedPublicKey(compressedPublicKey: ecPrivateKey.ecPublicKey.compressed);
+    return Secp256k1PrivateKey(ecPrivateKey: ecPrivateKey, metadata: updatedMetadata);
+  }
+
+  factory Secp256k1PrivateKey.fromExtendedPrivateKey(String extendedPrivateKey) {
+    Uint8List decodedXPrv = Base58Encoder.decode(extendedPrivateKey);
+    List<Uint8List> decodedXPubParts = BytesUtils.chunkBytes(bytes: decodedXPrv, chunkSizes: ABip32PrivateKey.xprvChunkSizes);
+
+    BigInt depth = BigIntUtils.decode(decodedXPubParts[1]);
+    BigInt parentFingerprint = BigIntUtils.decode(decodedXPubParts[2]);
+    BigInt shiftedIndex = BigIntUtils.decode(decodedXPubParts[3]);
+    Uint8List chainCode = decodedXPubParts[4];
+    Uint8List privateKeyBytes = decodedXPubParts[5];
+
+    Secp256k1PrivateKey privateKey = Secp256k1PrivateKey.fromBytes(privateKeyBytes.sublist(1));
+
+    return Secp256k1PrivateKey.fromBytes(
+      privateKey.bytes,
+      metadata: Bip32KeyMetadata.fromCompressedPublicKey(
+        compressedPublicKey: privateKey.publicKey.compressed,
+        depth: depth.toInt(),
+        chainCode: chainCode,
+        parentFingerprint: parentFingerprint,
+        shiftedIndex: shiftedIndex.toInt(),
+      ),
+    );
+  }
 
   /// Returns the private key as a byte array.
   @override
@@ -30,5 +60,5 @@ class Secp256k1PrivateKey extends ABip32PrivateKey {
   }
 
   @override
-  List<Object?> get props => <Object>[ecPrivateKey, metadata];
+  List<Object?> get props => <Object?>[ecPrivateKey, metadata];
 }

--- a/lib/src/utils/bytes_utils.dart
+++ b/lib/src/utils/bytes_utils.dart
@@ -12,4 +12,14 @@ class BytesUtils {
     List<int> bytes = BigIntUtils.changeToBytes(z2, length: padding.bitLength ~/ 8);
     return Uint8List.fromList(bytes);
   }
+
+  static List<Uint8List> chunkBytes({required Uint8List bytes, required List<int> chunkSizes}) {
+    List<Uint8List> chunks = <Uint8List>[];
+    int offset = 0;
+    for (int chunkSize in chunkSizes) {
+      chunks.add(bytes.sublist(offset, offset + chunkSize));
+      offset += chunkSize;
+    }
+    return chunks;
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cryptography_utils
 description: "Dart package containing utility methods for common cryptographic and blockchain-specific operations"
-version: 0.0.14
+version: 0.0.15
 
 environment:
   sdk: ">=3.2.6"

--- a/test/bip/bip32/bip32_key_metadata_test.dart
+++ b/test/bip/bip32/bip32_key_metadata_test.dart
@@ -1,0 +1,153 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of Bip32KeyMetadata.fromCompressedPublicKey() constructor', () {
+    test('Should [return Bip32KeyMetadata] with fingerprint if only public key provided', () {
+      // Arrange
+      Uint8List actualCompressedPublicKey = base64Decode('Ar+tLoQUarMHBlWt2YHvheCerhvBi3VacJya8XNUx2Yj');
+
+      // Act
+      Bip32KeyMetadata actualBip32KeyMetadata = Bip32KeyMetadata.fromCompressedPublicKey(compressedPublicKey: actualCompressedPublicKey);
+
+      // Assert
+      Bip32KeyMetadata expectedBip32KeyMetadata = Bip32KeyMetadata(fingerprint: BigInt.parse('83580899'));
+
+      expect(actualBip32KeyMetadata, expectedBip32KeyMetadata);
+    });
+
+    test('Should [return FILLED Bip32KeyMetadata] if all values provided', () {
+      // Arrange
+      Uint8List actualCompressedPublicKey = base64Decode('Ar+tLoQUarMHBlWt2YHvheCerhvBi3VacJya8XNUx2Yj');
+
+      // Act
+      Bip32KeyMetadata actualBip32KeyMetadata = Bip32KeyMetadata.fromCompressedPublicKey(
+        compressedPublicKey: actualCompressedPublicKey,
+        depth: 0,
+        parentFingerprint: BigInt.parse('0'),
+        masterFingerprint: BigInt.parse('83580899'),
+        chainCode: base64Decode('UNH2aBl1uMkP+S/i5vZVK8tC2uODdICFW0hrpY8Zrbk='),
+      );
+
+      // Assert
+      Bip32KeyMetadata expectedBip32KeyMetadata = Bip32KeyMetadata(
+        fingerprint: BigInt.parse('83580899'),
+        depth: 0,
+        parentFingerprint: BigInt.parse('0'),
+        masterFingerprint: BigInt.parse('83580899'),
+        chainCode: base64Decode('UNH2aBl1uMkP+S/i5vZVK8tC2uODdICFW0hrpY8Zrbk='),
+      );
+
+      expect(actualBip32KeyMetadata, expectedBip32KeyMetadata);
+    });
+  });
+
+  group('Tests of Bip32KeyMetadata.deriveNext()', () {
+    test('Should [return Bip32KeyMetadata] for the next derived public key', () {
+      // Arrange
+      Bip32KeyMetadata actualBip32KeyMetadata = Bip32KeyMetadata(
+        depth: 3,
+        shiftedIndex: 2147483648,
+        chainCode: base64Decode('5gvokyLRAipECLgT5AnkPLX6thREo+E27t5wUBpna9w='),
+        fingerprint: BigInt.parse('2583323534'),
+        parentFingerprint: BigInt.parse('2923058245'),
+        masterFingerprint: BigInt.parse('83580899'),
+      );
+
+      // Act
+      Bip32KeyMetadata actualNextBip32KeyMetadata = actualBip32KeyMetadata.deriveNext(
+        newChainCode: base64Decode('FK0bd1Z1KEZpXlZ45+GufE0HsweNVoh7EkZndgnxmVA='),
+        newCompressedPublicKey: base64Decode('A4O/mtYg93+ocKaEonuS/GMTWAWEy2jkBPAFtAmu1h8X'),
+        newShiftedIndex: 0,
+      );
+
+      // Assert
+      Bip32KeyMetadata expectedNextBip32KeyMetadata = Bip32KeyMetadata(
+        depth: 4,
+        shiftedIndex: 0,
+        chainCode: base64Decode('FK0bd1Z1KEZpXlZ45+GufE0HsweNVoh7EkZndgnxmVA='),
+        fingerprint: BigInt.parse('162080603'),
+        parentFingerprint: BigInt.parse('2583323534'),
+        masterFingerprint: BigInt.parse('83580899'),
+      );
+
+      expect(actualNextBip32KeyMetadata, expectedNextBip32KeyMetadata);
+    });
+  });
+
+  group('Tests of Bip32KeyMetadata.canBuildExtendedKey getter', () {
+    test('Should [return TRUE] if Bip32KeyMetadata [contains all parameters] required to build extended key', () {
+      // Arrange
+      Bip32KeyMetadata actualBip32KeyMetadata = Bip32KeyMetadata(
+        depth: 4,
+        shiftedIndex: 0,
+        chainCode: base64Decode('FK0bd1Z1KEZpXlZ45+GufE0HsweNVoh7EkZndgnxmVA='),
+        fingerprint: BigInt.parse('162080603'),
+        parentFingerprint: BigInt.parse('2583323534'),
+        masterFingerprint: BigInt.parse('83580899'),
+      );
+
+      // Assert
+      expect(actualBip32KeyMetadata.canBuildExtendedKey, true);
+    });
+
+    test('Should [return FALSE] if Bip32KeyMetadata has [depth missing]', () {
+      // Arrange
+      Bip32KeyMetadata actualBip32KeyMetadata = Bip32KeyMetadata(
+        shiftedIndex: 0,
+        chainCode: base64Decode('FK0bd1Z1KEZpXlZ45+GufE0HsweNVoh7EkZndgnxmVA='),
+        fingerprint: BigInt.parse('162080603'),
+        parentFingerprint: BigInt.parse('2583323534'),
+        masterFingerprint: BigInt.parse('83580899'),
+      );
+
+      // Assert
+      expect(actualBip32KeyMetadata.canBuildExtendedKey, false);
+    });
+
+    test('Should [return FALSE] if Bip32KeyMetadata has [parentFingerprint missing]', () {
+      // Arrange
+      Bip32KeyMetadata actualBip32KeyMetadata = Bip32KeyMetadata(
+        depth: 4,
+        shiftedIndex: 0,
+        chainCode: base64Decode('FK0bd1Z1KEZpXlZ45+GufE0HsweNVoh7EkZndgnxmVA='),
+        fingerprint: BigInt.parse('162080603'),
+        masterFingerprint: BigInt.parse('83580899'),
+      );
+
+      // Assert
+      expect(actualBip32KeyMetadata.canBuildExtendedKey, false);
+    });
+
+    test('Should [return FALSE] if Bip32KeyMetadata has [chainCode missing]', () {
+      // Arrange
+      Bip32KeyMetadata actualBip32KeyMetadata = Bip32KeyMetadata(
+        depth: 4,
+        shiftedIndex: 0,
+        fingerprint: BigInt.parse('162080603'),
+        parentFingerprint: BigInt.parse('2583323534'),
+        masterFingerprint: BigInt.parse('83580899'),
+      );
+
+      // Assert
+      expect(actualBip32KeyMetadata.canBuildExtendedKey, false);
+    });
+
+    test('Should [return FALSE] if Bip32KeyMetadata has [shiftedIndex missing]', () {
+      // Arrange
+      Bip32KeyMetadata actualBip32KeyMetadata = Bip32KeyMetadata(
+        depth: 4,
+        chainCode: base64Decode('FK0bd1Z1KEZpXlZ45+GufE0HsweNVoh7EkZndgnxmVA='),
+        fingerprint: BigInt.parse('162080603'),
+        parentFingerprint: BigInt.parse('2583323534'),
+        masterFingerprint: BigInt.parse('83580899'),
+      );
+
+      // Assert
+      expect(actualBip32KeyMetadata.canBuildExtendedKey, false);
+    });
+  });
+}

--- a/test/bip/bip32/derivators/legacy_derivators/secp256k1_derivator_test.dart
+++ b/test/bip/bip32/derivators/legacy_derivators/secp256k1_derivator_test.dart
@@ -405,4 +405,116 @@ void main() {
       expect(actualChildSecp256k1PrivateKey, expectedChildSecp256k1PrivateKey);
     });
   });
+
+  group('Secp256k1Derivator.derivePublicKey()', () {
+    test("Should [return Secp256k1PublicKey] constructed from Secp256k1PublicKey and DerivationPathElement (m/44'/60'/0'/ -> m/44'/60'/0'/0/)", () {
+      // Arrange
+      LegacyDerivationPathElement actualDerivationPathElement = LegacyDerivationPathElement.parse('0');
+
+      // Private key derived from m/44'/60'/0' derivation path (value calculated in the previous test)
+      Secp256k1PublicKey actualSecp256k1PublicKey = Secp256k1PublicKey(
+        ecPublicKey: ECPublicKey(
+          CurvePoints.generatorSecp256k1,
+          ECPoint(
+            curve: Curves.secp256k1,
+            n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+            x: BigInt.parse('75511275616717823953127492513872404089510520934241368065606359089209257930911'),
+            y: BigInt.parse('80307866468962207790115496269216787987906781244125604767016195777199780913020'),
+            z: BigInt.parse('48316583892506475825569737992841455467679195882745032601597666604627327182481'),
+          ),
+        ),
+        metadata: Bip32KeyMetadata(
+          depth: 3,
+          shiftedIndex: 2147483648,
+          chainCode: base64Decode('5gvokyLRAipECLgT5AnkPLX6thREo+E27t5wUBpna9w='),
+          fingerprint: BigInt.parse('2583323534'),
+          parentFingerprint: BigInt.parse('2923058245'),
+          masterFingerprint: BigInt.parse('83580899'),
+        ),
+      );
+
+      // Act
+      Secp256k1PublicKey actualChildSecp256k1PublicKey = actualSecp256k1Derivator.derivePublicKey(actualSecp256k1PublicKey, actualDerivationPathElement);
+
+      // Assert
+      // Public key derived from m/44'/60'/0'/0 derivation path
+      Secp256k1PublicKey expectedSecp256k1PublicKey = Secp256k1PublicKey(
+        ecPublicKey: ECPublicKey(
+          CurvePoints.generatorSecp256k1,
+          ECPoint(
+            curve: Curves.secp256k1,
+            n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+            x: BigInt.parse('7391357532699440077661224140469825051828763295397368622370962838828358580994'),
+            y: BigInt.parse('96993176887215260937294338881510705358928133747744922014432146730509477720447'),
+            z: BigInt.parse('61878165241971238318861094125952078285108407352520420552419041993662987147055'),
+          ),
+        ),
+        metadata: Bip32KeyMetadata(
+          depth: 4,
+          shiftedIndex: 0,
+          chainCode: base64Decode('FK0bd1Z1KEZpXlZ45+GufE0HsweNVoh7EkZndgnxmVA='),
+          fingerprint: BigInt.parse('162080603'),
+          parentFingerprint: BigInt.parse('2583323534'),
+          masterFingerprint: BigInt.parse('83580899'),
+        ),
+      );
+
+      expect(actualChildSecp256k1PublicKey, expectedSecp256k1PublicKey);
+    });
+
+    test("Should [return Secp256k1PublicKey] constructed from Secp256k1PublicKey and DerivationPathElement (m/44'/60'/0'/0/ -> m/44'/60'/0'/0/0)", () {
+      // Arrange
+      LegacyDerivationPathElement actualDerivationPathElement = LegacyDerivationPathElement.parse('0');
+
+      // Private key derived from m/44'/60'/0'/0 derivation path (value calculated in the previous test)
+      Secp256k1PublicKey actualSecp256k1PublicKey = Secp256k1PublicKey(
+        ecPublicKey: ECPublicKey(
+          CurvePoints.generatorSecp256k1,
+          ECPoint(
+            curve: Curves.secp256k1,
+            n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+            x: BigInt.parse('7391357532699440077661224140469825051828763295397368622370962838828358580994'),
+            y: BigInt.parse('96993176887215260937294338881510705358928133747744922014432146730509477720447'),
+            z: BigInt.parse('61878165241971238318861094125952078285108407352520420552419041993662987147055'),
+          ),
+        ),
+        metadata: Bip32KeyMetadata(
+          depth: 4,
+          shiftedIndex: 0,
+          chainCode: base64Decode('FK0bd1Z1KEZpXlZ45+GufE0HsweNVoh7EkZndgnxmVA='),
+          fingerprint: BigInt.parse('162080603'),
+          parentFingerprint: BigInt.parse('2583323534'),
+          masterFingerprint: BigInt.parse('83580899'),
+        ),
+      );
+
+      // Act
+      Secp256k1PublicKey actualChildSecp256k1PublicKey = actualSecp256k1Derivator.derivePublicKey(actualSecp256k1PublicKey, actualDerivationPathElement);
+
+      // Assert
+      // Public key derived from m/44'/60'/0'/0/0 derivation path
+      Secp256k1PublicKey expectedSecp256k1PublicKey = Secp256k1PublicKey(
+        ecPublicKey: ECPublicKey(
+          CurvePoints.generatorSecp256k1,
+          ECPoint(
+            curve: Curves.secp256k1,
+            n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+            x: BigInt.parse('9232382608412632023364058986292255060162006357143939392524352546547404109067'),
+            y: BigInt.parse('24525960969333389592602277560509258313992338161474124632221076070267967860241'),
+            z: BigInt.parse('19124601255334300034768219253657747232341817211804968472451971716379867526946'),
+          ),
+        ),
+        metadata: Bip32KeyMetadata(
+          depth: 5,
+          shiftedIndex: 0,
+          chainCode: base64Decode('YsN74zJ6p9/kjsFCM5UUBq470XR3CEssHXyawdn7xBw='),
+          fingerprint: BigInt.parse('2837893204'),
+          parentFingerprint: BigInt.parse('162080603'),
+          masterFingerprint: BigInt.parse('83580899'),
+        ),
+      );
+
+      expect(actualChildSecp256k1PublicKey, expectedSecp256k1PublicKey);
+    });
+  });
 }

--- a/test/cdsa/ecdsa/ec_point_test.dart
+++ b/test/cdsa/ecdsa/ec_point_test.dart
@@ -39,6 +39,48 @@ void main() {
     });
   });
 
+  group('Tests of ECPoint.fromCompressedBytes() constructor', () {
+    test('Should [return ECPoint] from [COMPRESSED bytes]', () {
+      // Arrange
+      Uint8List actualCompressedBytes = base64Decode('Ar+tLoQUarMHBlWt2YHvheCerhvBi3VacJya8XNUx2Yj');
+
+      // Act
+      ECPoint actualECPoint = ECPoint.fromCompressedBytes(actualCompressedBytes, CurvePoints.generatorSecp256k1);
+
+      // Assert
+      ECPoint expectedECPoint = ECPoint(
+        curve: Curves.secp256k1,
+        n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+        x: BigInt.parse('109809582697629541179477143463768131161650648020283737506803606109779771350309'),
+        y: BigInt.parse('93904199375389538639503047221917403320671286887529822165996195593332713512966'),
+        z: BigInt.parse('15114296647857780461657875995579731758281183768828053400819025202844531705682'),
+      );
+
+      expect(actualECPoint, expectedECPoint);
+    });
+  });
+
+  group('Tests of ECPoint.fromUncompressedBytes() constructor', () {
+    test('Should [return ECPoint] from [UNCOMPRESSED bytes]', () {
+      // Arrange
+      Uint8List actualUncompressedBytes = base64Decode('v60uhBRqswcGVa3Zge+F4J6uG8GLdVpwnJrxc1THZiNF2HjK8gm8RXiyE3BzH9skj5ZSZ7cMZ/LVK5GUGY8Dig==');
+
+      // Act
+      ECPoint actualECPoint = ECPoint.fromUncompressedBytes(actualUncompressedBytes, CurvePoints.generatorSecp256k1);
+
+      // Assert
+      ECPoint expectedECPoint = ECPoint(
+        curve: Curves.secp256k1,
+        n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+        x: BigInt.parse('109809582697629541179477143463768131161650648020283737506803606109779771350309'),
+        y: BigInt.parse('93904199375389538639503047221917403320671286887529822165996195593332713512966'),
+        z: BigInt.parse('15114296647857780461657875995579731758281183768828053400819025202844531705682'),
+      );
+
+      expect(actualECPoint, expectedECPoint);
+    });
+  });
+
   group('Tests of ECPoint - (negation) operator overload', () {
     test('Should [return ECPoint] with negated y coordinate', () {
       // Arrange

--- a/test/cdsa/ecdsa/ec_public_key_test.dart
+++ b/test/cdsa/ecdsa/ec_public_key_test.dart
@@ -5,6 +5,54 @@ import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('Tests of ECPublicKey.fromCompressedBytes() getter', () {
+    test('Should [return ECPublicKey] from [COMPRESSED bytes]', () {
+      // Arrange
+      Uint8List actualCompressedBytes = base64Decode('Ar+tLoQUarMHBlWt2YHvheCerhvBi3VacJya8XNUx2Yj');
+
+      // Act
+      ECPublicKey actualECPublicKey = ECPublicKey.fromCompressedBytes(actualCompressedBytes, CurvePoints.generatorSecp256k1);
+
+      // Assert
+      ECPublicKey expectedECPublicKey = ECPublicKey(
+        CurvePoints.generatorSecp256k1,
+        ECPoint(
+          curve: Curves.secp256k1,
+          n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+          x: BigInt.parse('109809582697629541179477143463768131161650648020283737506803606109779771350309'),
+          y: BigInt.parse('93904199375389538639503047221917403320671286887529822165996195593332713512966'),
+          z: BigInt.parse('15114296647857780461657875995579731758281183768828053400819025202844531705682'),
+        ),
+      );
+
+      expect(actualECPublicKey, expectedECPublicKey);
+    });
+  });
+
+  group('Tests of ECPublicKey.fromUncompressedBytes() getter', () {
+    test('Should [return ECPublicKey] from [UNCOMPRESSED bytes]', () {
+      // Arrange
+      Uint8List actualUncompressedBytes = base64Decode('BL+tLoQUarMHBlWt2YHvheCerhvBi3VacJya8XNUx2YjRdh4yvIJvEV4shNwcx/bJI+WUme3DGfy1SuRlBmPA4o=');
+
+      // Act
+      ECPublicKey actualECPublicKey = ECPublicKey.fromUncompressedBytes(actualUncompressedBytes, CurvePoints.generatorSecp256k1);
+
+      // Assert
+      ECPublicKey expectedECPublicKey = ECPublicKey(
+        CurvePoints.generatorSecp256k1,
+        ECPoint(
+          curve: Curves.secp256k1,
+          n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+          x: BigInt.parse('109809582697629541179477143463768131161650648020283737506803606109779771350309'),
+          y: BigInt.parse('93904199375389538639503047221917403320671286887529822165996195593332713512966'),
+          z: BigInt.parse('15114296647857780461657875995579731758281183768828053400819025202844531705682'),
+        ),
+      );
+
+      expect(actualECPublicKey, expectedECPublicKey);
+    });
+  });
+
   group('Tests of ECPublicKey.compressed getter', () {
     test('Should [return bytes] representing [COMPRESSED ECPublicKey] (Secp256k1)', () {
       // Arrange
@@ -27,7 +75,9 @@ void main() {
 
       expect(actualCompressedPublicKey, expectedCompressedPublicKey);
     });
+  });
 
+  group('Tests of ECPublicKey.uncompressed getter', () {
     test('Should [return bytes] representing [UNCOMPRESSED ECPublicKey] (Secp256k1)', () {
       // Assert
       ECPublicKey ecPublicKey = ECPublicKey(

--- a/test/cdsa/ecdsa/secp256k1/secp256k1_private_key_test.dart
+++ b/test/cdsa/ecdsa/secp256k1/secp256k1_private_key_test.dart
@@ -5,8 +5,56 @@ import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('Tests of Secp256k1PrivateKey.fromBytes() constructor', () {
+    test('Should [return Secp256k1PrivateKey] constructed from bytes', () {
+      // Arrange
+      Uint8List actualPrivateKeyBytes = base64Decode('IxMiv7h+lmU8ouyK8Ds+wP5EL/n1Kv0TKJft3E0Kf8M=');
+
+      // Act
+      Secp256k1PrivateKey actualSecp256k1PrivateKey = Secp256k1PrivateKey.fromBytes(actualPrivateKeyBytes);
+
+      // Assert
+      Secp256k1PrivateKey expectedSecp256k1PrivateKey = Secp256k1PrivateKey(
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('15864759622800253937020257025334897817812874204769186060960403729801414344643'),
+        ),
+        metadata: Bip32KeyMetadata(fingerprint: BigInt.parse('83580899')),
+      );
+
+      expect(actualSecp256k1PrivateKey, expectedSecp256k1PrivateKey);
+    });
+  });
+
+  group('Tests of Secp256k1PrivateKey.fromExtendedPrivateKey() constructor', () {
+    test('Should [return Secp256k1PrivateKey] constructed from xprv', () {
+      // Arrange
+      String actualExtendedPrivateKey = 'xprvA2VojMGQ8s55ciBWHZFdQm8Y4fUPs8ZKRH4qgsoPw8cjfpHFKoutqeXsD1N9p5ShLBM8vBDGmDMaEFTERkMC1FvqWPDoVK2kFG3ffLAikXM';
+
+      // Act
+      Secp256k1PrivateKey actualSecp256k1PrivateKey = Secp256k1PrivateKey.fromExtendedPrivateKey(actualExtendedPrivateKey);
+
+      // Assert
+      Secp256k1PrivateKey expectedSecp256k1PrivateKey = Secp256k1PrivateKey(
+        ecPrivateKey: ECPrivateKey(
+          CurvePoints.generatorSecp256k1,
+          BigInt.parse('91850346642365090382529827989594437164777469345439968194889143349494450093883'),
+        ),
+        metadata: Bip32KeyMetadata(
+          depth: 5,
+          shiftedIndex: 0,
+          fingerprint: BigInt.parse('2837893204'),
+          parentFingerprint: BigInt.parse('162080603'),
+          chainCode: base64Decode('YsN74zJ6p9/kjsFCM5UUBq470XR3CEssHXyawdn7xBw='),
+        ),
+      );
+
+      expect(actualSecp256k1PrivateKey, expectedSecp256k1PrivateKey);
+    });
+  });
+
   group('Tests of Secp256k1PrivateKey.getExtendedPrivateKey() getter', () {
-    test('Should [return xpriv] representing extended private key', () {
+    test('Should [return xprv] representing extended private key', () {
       // Arrange
       Secp256k1PrivateKey actualSecp256k1PrivateKey = Secp256k1PrivateKey(
         ecPrivateKey: ECPrivateKey(

--- a/test/cdsa/ecdsa/secp256k1/secp256k1_public_key_test.dart
+++ b/test/cdsa/ecdsa/secp256k1/secp256k1_public_key_test.dart
@@ -5,6 +5,93 @@ import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('Tests of Secp256k1PublicKey.fromCompressedBytes() getter', () {
+    test('Should [return Secp256k1PublicKey] constructed from [COMPRESSED bytes]', () {
+      // Arrange
+      Uint8List actualCompressedBytes = base64Decode('Ar+tLoQUarMHBlWt2YHvheCerhvBi3VacJya8XNUx2Yj');
+
+      // Act
+      Secp256k1PublicKey actualSecp256k1PublicKey = Secp256k1PublicKey.fromCompressedBytes(actualCompressedBytes);
+
+      // Assert
+      Secp256k1PublicKey expectedSecp256k1PublicKey = Secp256k1PublicKey(
+        ecPublicKey: ECPublicKey(
+          CurvePoints.generatorSecp256k1,
+          ECPoint(
+            curve: Curves.secp256k1,
+            n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+            x: BigInt.parse('109809582697629541179477143463768131161650648020283737506803606109779771350309'),
+            y: BigInt.parse('93904199375389538639503047221917403320671286887529822165996195593332713512966'),
+            z: BigInt.parse('15114296647857780461657875995579731758281183768828053400819025202844531705682'),
+          ),
+        ),
+        metadata: Bip32KeyMetadata(fingerprint: BigInt.parse('83580899')),
+      );
+
+      expect(actualSecp256k1PublicKey, expectedSecp256k1PublicKey);
+    });
+  });
+
+  group('Tests of Secp256k1PublicKey.fromUncompressedBytes() getter', () {
+    test('Should [return Secp256k1PublicKey] constructed from [UNCOMPRESSED bytes]', () {
+      // Arrange
+      Uint8List actualUncompressedBytes = base64Decode('BL+tLoQUarMHBlWt2YHvheCerhvBi3VacJya8XNUx2YjRdh4yvIJvEV4shNwcx/bJI+WUme3DGfy1SuRlBmPA4o=');
+
+      // Act
+      Secp256k1PublicKey actualSecp256k1PublicKey = Secp256k1PublicKey.fromUncompressedBytes(actualUncompressedBytes);
+
+      // Assert
+      Secp256k1PublicKey expectedSecp256k1PublicKey = Secp256k1PublicKey(
+        ecPublicKey: ECPublicKey(
+          CurvePoints.generatorSecp256k1,
+          ECPoint(
+            curve: Curves.secp256k1,
+            n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+            x: BigInt.parse('109809582697629541179477143463768131161650648020283737506803606109779771350309'),
+            y: BigInt.parse('93904199375389538639503047221917403320671286887529822165996195593332713512966'),
+            z: BigInt.parse('15114296647857780461657875995579731758281183768828053400819025202844531705682'),
+          ),
+        ),
+        metadata: Bip32KeyMetadata(fingerprint: BigInt.parse('83580899')),
+      );
+
+      expect(actualSecp256k1PublicKey, expectedSecp256k1PublicKey);
+    });
+  });
+
+  group('Tests of Secp256k1PublicKey.fromExtendedPublicKey() getter', () {
+    test('Should [return Secp256k1PublicKey] constructed from xpub', () {
+      // Arrange
+      String actualExtendedPublicKey = 'xpub6FVA8roHyEdNqCFyPandmu5GchJtGbHAnVzSVGD1VU9iYccPsME9PSrM4Jf2BFkcAkLV5bTyPVjxqZMdQz6tWhq8T1DSj48ADHABqV4n3vL';
+
+      // Act
+      Secp256k1PublicKey actualSecp256k1PublicKey = Secp256k1PublicKey.fromExtendedPublicKey(actualExtendedPublicKey);
+
+      // Assert
+      Secp256k1PublicKey expectedSecp256k1PublicKey = Secp256k1PublicKey(
+        ecPublicKey: ECPublicKey(
+          CurvePoints.generatorSecp256k1,
+          ECPoint(
+            curve: Curves.secp256k1,
+            n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+            x: BigInt.parse('49844093485842753019501723164709087800134847594852664670182601545797061237061'),
+            y: BigInt.parse('102584019795063234624860865414832132871049165551248963828805190591824528686504'),
+            z: BigInt.parse('33112508886275853310422687256511308836721055527980470378416551104097868981749'),
+          ),
+        ),
+        metadata: Bip32KeyMetadata(
+          depth: 5,
+          shiftedIndex: 0,
+          fingerprint: BigInt.parse('2837893204'),
+          parentFingerprint: BigInt.parse('162080603'),
+          chainCode: base64Decode('YsN74zJ6p9/kjsFCM5UUBq470XR3CEssHXyawdn7xBw='),
+        ),
+      );
+
+      expect(actualSecp256k1PublicKey, expectedSecp256k1PublicKey);
+    });
+  });
+
   group('Tests of Secp256k1PublicKey.getExtendedPublicKey() getter', () {
     test('Should [return xpub] representing extended public key', () {
       // Arrange
@@ -78,39 +165,6 @@ void main() {
     });
   });
 
-  group('Tests of Secp256k1PublicKey.bytes getter', () {
-    test('Should [return bytes] representing [Secp256k1PublicKey]', () {
-      // Arrange
-      Secp256k1PublicKey actualSecp256k1PublicKey = Secp256k1PublicKey(
-        ecPublicKey: ECPublicKey(
-          CurvePoints.generatorSecp256k1,
-          ECPoint(
-            curve: Curves.secp256k1,
-            n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
-            x: BigInt.parse('109809582697629541179477143463768131161650648020283737506803606109779771350309'),
-            y: BigInt.parse('93904199375389538639503047221917403320671286887529822165996195593332713512966'),
-            z: BigInt.parse('15114296647857780461657875995579731758281183768828053400819025202844531705682'),
-          ),
-        ),
-        metadata: Bip32KeyMetadata(
-          depth: 0,
-          fingerprint: BigInt.parse('83580899'),
-          parentFingerprint: BigInt.parse('0'),
-          masterFingerprint: BigInt.parse('83580899'),
-          chainCode: base64Decode('UNH2aBl1uMkP+S/i5vZVK8tC2uODdICFW0hrpY8Zrbk='),
-        ),
-      );
-
-      // Act
-      Uint8List actualCompressedPublicKey = actualSecp256k1PublicKey.compressed;
-
-      // Assert
-      Uint8List expectedCompressedPublicKey = base64Decode('Ar+tLoQUarMHBlWt2YHvheCerhvBi3VacJya8XNUx2Yj');
-
-      expect(actualCompressedPublicKey, expectedCompressedPublicKey);
-    });
-  });
-
   group('Tests of Secp256k1PublicKey.compressed getter', () {
     test('Should [return bytes] representing [COMPRESSED Secp256k1PublicKey]', () {
       // Arrange
@@ -168,12 +222,12 @@ void main() {
       );
 
       // Act
-      Uint8List actualCompressedPublicKey = actualSecp256k1PublicKey.uncompressed;
+      Uint8List actualUncompressedPublicKey = actualSecp256k1PublicKey.uncompressed;
 
       // Assert
-      Uint8List expectedCompressedPublicKey = base64Decode('BL+tLoQUarMHBlWt2YHvheCerhvBi3VacJya8XNUx2YjRdh4yvIJvEV4shNwcx/bJI+WUme3DGfy1SuRlBmPA4o=');
+      Uint8List expectedUncompressedPublicKey = base64Decode('BL+tLoQUarMHBlWt2YHvheCerhvBi3VacJya8XNUx2YjRdh4yvIJvEV4shNwcx/bJI+WUme3DGfy1SuRlBmPA4o=');
 
-      expect(actualCompressedPublicKey, expectedCompressedPublicKey);
+      expect(actualUncompressedPublicKey, expectedUncompressedPublicKey);
     });
   });
 }

--- a/test/utils/bytes_utils_test.dart
+++ b/test/utils/bytes_utils_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:test/test.dart';
@@ -47,6 +48,29 @@ void main() {
       List<int> expectedPaddedBytes = base64Decode('ZXhjbHVkZSB3ZXN0IG5vYmxlIHB1cml0eSBiZXlvbmQ=');
 
       expect(actualPaddedBytes, expectedPaddedBytes);
+    });
+  });
+
+  group('Tests of BytesUtils.chunkBytes()', () {
+    test('Should [return chunked bytes] with specified chunk sized', () {
+      // Arrange
+      Uint8List actualBytesToChunk = Uint8List.fromList(<int>[1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6]);
+      List<int> actualChunkSizes = <int>[1, 2, 3, 4, 5, 6];
+
+      // Act
+      List<Uint8List> actualChunkedBytes = BytesUtils.chunkBytes(bytes: actualBytesToChunk, chunkSizes: actualChunkSizes);
+
+      // Assert
+      List<Uint8List> expectedChunkedBytes = <Uint8List>[
+        Uint8List.fromList(<int>[1]),
+        Uint8List.fromList(<int>[2, 2]),
+        Uint8List.fromList(<int>[3, 3, 3]),
+        Uint8List.fromList(<int>[4, 4, 4, 4]),
+        Uint8List.fromList(<int>[5, 5, 5, 5, 5]),
+        Uint8List.fromList(<int>[6, 6, 6, 6, 6, 6]),
+      ];
+
+      expect(actualChunkedBytes, expectedChunkedBytes);
     });
   });
 }


### PR DESCRIPTION
The purpose of this branch is to add functionality for building public/private keys from bytes and their extended version (xpub, xprv). It was made to simplify decoding and storage of keys received from trezor.io (MIRAGE) and database (SNGGLE). Branch also includes deriving a public key from another public key so that MIRAGE can perform more calculations on their side, minimizing requests to SNGGLE.

List of changes:
- created new method in secp256k1_derivator.dart to derive Secp256k1PublicKey from other Secp256k1PublicKey (derivation without Secp256k1PrivateKey)
- created fromBytes() constructor in secp256k1_private_key.dart to allow building Secp256k1PrivateKey from bytes
- created fromCompressedBytes(), fromUncompressedBytes() constructors in secp256k1_public_key.dart to allow building Secp256k1PublicKey from bytes
- created fromCompressedBytes(), fromUncompressedBytes() constructors in ec_public_key.dart to allow building ECPublicKey from bytes
- created fromCompressedBytes(), fromUncompressedBytes() constructors in ec_point.dart to allow building ECPoint from bytes as it was necessary to provide similar functionalities in secp256k1_public_key.dart, ec_public_key.dart
- created new fromExtendedPrivateKey() constructor in secp256k1_private_key.dart to allow building Secp256k1PrivateKey from xprv string
- created new fromExtendedPublicKey() constructor in secp256k1_public_key.dart to allow building Secp256k1PublicKey from xpub string
- updated bip32_key_metadata.dart to have most of the fields nullable, as the key built from bytes does not contain metadata information. The only parameter that can be calculated is "fingerprint" which is left as required.
- added "fromPrivateKey()" method to legacy_hd_wallet.dart to allow creating LegacyHDWallet without the need for passing mnemonic