### PR TITLE
Feature: Cosmos signing

### DIFF
--- a/lib/src/signer/cosmos/cosmos_signature.dart
+++ b/lib/src/signer/cosmos/cosmos_signature.dart
@@ -1,0 +1,34 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:cryptography_utils/src/utils/big_int_utils.dart';
+
+/// Represents a Cosmos digital signature, encapsulating the typical components of an ECDSA signature used in Cosmos transactions.
+class CosmosSignature extends ASignature {
+  /// Part of the signature that corresponds to the x-coordinate of the ephemeral public key,
+  /// serving as a representation of the signature on the elliptic curve. Typically denoted as 'r'.
+  final BigInt r;
+
+  /// Part of the signature representing the scalar component, typically denoted as 's'.
+  /// Derived from the signer's private key and the hash of the message, this component serves as the proof of
+  /// the signature's authenticity and the signer's agreement with the message content.
+  final BigInt s;
+
+  /// Constructs an instance of [CosmosSignature] with the specified [s] and [r] components.
+  const CosmosSignature({
+    required this.r,
+    required this.s,
+  });
+
+  /// Returns new [CosmosSignature] instance with the overridden values.
+  @override
+  Uint8List get bytes {
+    List<int> rBytes = BigIntUtils.changeToBytes(r, length: 32);
+    List<int> sBytes = BigIntUtils.changeToBytes(s, length: 32);
+
+    return Uint8List.fromList(rBytes + sBytes);
+  }
+
+  @override
+  List<Object?> get props => <Object>[r, s];
+}

--- a/lib/src/signer/cosmos/cosmos_signer.dart
+++ b/lib/src/signer/cosmos/cosmos_signer.dart
@@ -1,0 +1,58 @@
+// Class was shaped by the influence of several key sources including:
+// "blockchain_utils" - Copyright (c) 2010 Mohsen
+// https://github.com/mrtnetwork/blockchain_utils/.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// Provides functionality for creating Cosmos-compatible digital signatures using an ECDSA private key.
+class CosmosSigner {
+  /// The ECDSA private key used for signing messages.
+  final ECPrivateKey _ecPrivateKey;
+
+  /// Constructs an [CosmosSigner] with the provided ECDSA private key.
+  CosmosSigner(this._ecPrivateKey);
+
+  /// Signs given [CosmosSignDoc] using SIGN_MODE_DIRECT and returns the signature as an [CosmosSignature].
+  CosmosSignature signDirect(CosmosSignDoc signDoc) {
+    ECDSASigner ecdsaSigner = ECDSASigner(hashFunction: sha256, ecPrivateKey: _ecPrivateKey);
+    CosmosVerifier cosmosVerifier = CosmosVerifier(_ecPrivateKey.ecPublicKey);
+
+    Uint8List signBytes = signDoc.getDirectSignBytes();
+    Uint8List hashedSignBytes = Uint8List.fromList(sha256.convert(signBytes).bytes);
+
+    ECSignature ecSignature = ecdsaSigner.sign(hashedSignBytes);
+
+    if (ecSignature.s > (_ecPrivateKey.G.n >> 1)) {
+      ecSignature = ECSignature(r: ecSignature.r, s: _ecPrivateKey.G.n - ecSignature.s, ecCurve: ecSignature.ecCurve);
+    }
+
+    CosmosSignature cosmosSignature = CosmosSignature(r: ecSignature.r, s: ecSignature.s);
+
+    bool signatureValidBool = cosmosVerifier.isSignatureValid(signDoc, cosmosSignature);
+    if (signatureValidBool) {
+      return cosmosSignature;
+    } else {
+      throw StateError('The created signature (${cosmosSignature.base64}) does not pass verification.');
+    }
+  }
+}

--- a/lib/src/signer/cosmos/cosmos_verifier.dart
+++ b/lib/src/signer/cosmos/cosmos_verifier.dart
@@ -1,0 +1,28 @@
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:cryptography_utils/src/cdsa/ecdsa/signer/ecdsa_verifier.dart';
+
+/// Provides functionality for verifying Cosmos-compatible digital signatures using an ECDSA public key.
+/// This class is used to confirm that a given signature corresponds to a specific [CosmosSignDoc] and was created using
+/// the private key associated with the provided public key, thereby verifying the authenticity of the signature.
+class CosmosVerifier {
+  /// The ECDSA public key used to verify signatures.
+  final ECPublicKey _ecPublicKey;
+
+  /// Constructs an [CosmosVerifier] with the provided ECDSA public key.
+  /// This public key will be used for all signature verifications performed by instances of this class.
+  CosmosVerifier(this._ecPublicKey);
+
+  /// Verifies a signature against a provided digest and the public key stored in this verifier.
+  bool isSignatureValid(CosmosSignDoc signDoc, CosmosSignature cosmosSignature) {
+    ECDSAVerifier ecdsaVerifier = ECDSAVerifier(hashFunction: sha256, ecPublicKey: _ecPublicKey);
+    ECSignature ecSignature = ECSignature.fromBytes(cosmosSignature.bytes, ecCurve: _ecPublicKey.G.curve);
+
+    Uint8List signBytes = signDoc.getDirectSignBytes();
+    Uint8List hashedSignBytes = Uint8List.fromList(sha256.convert(signBytes).bytes);
+
+    return ecdsaVerifier.isSignatureValid(hashedSignBytes, ecSignature);
+  }
+}

--- a/lib/src/signer/export.dart
+++ b/lib/src/signer/export.dart
@@ -1,4 +1,11 @@
 export 'a_signature.dart';
+
+// Cosmos
+export 'cosmos/cosmos_signature.dart';
+export 'cosmos/cosmos_signer.dart';
+export 'cosmos/cosmos_verifier.dart';
+
+// Ethereum
 export 'ethereum/ethereum_signature.dart';
 export 'ethereum/ethereum_signer.dart';
 export 'ethereum/ethereum_verifier.dart';

--- a/lib/src/transactions/cosmos/cosmos_acc_address.dart
+++ b/lib/src/transactions/cosmos/cosmos_acc_address.dart
@@ -1,0 +1,36 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+
+/// Class representing a Cosmos account address
+/// https://docs.cosmos.network/v0.46/basics/accounts.html#addresses
+class CosmosAccAddress extends AProtobufField {
+  /// The human-readable part of the address
+  final String hrp;
+
+  /// The bytes of the address
+  final Uint8List bytes;
+
+  /// Creates [CosmosAccountAddress] from a Bech32 encoded address.
+  factory CosmosAccAddress(String address) {
+    Bech32Pair decodedBech32 = Bech32Codec.decode(address);
+    return CosmosAccAddress._(decodedBech32.hrp, decodedBech32.data);
+  }
+
+  /// Private constructor used by the factory to initialize the hrp and bytes.
+  const CosmosAccAddress._(this.hrp, this.bytes);
+
+  @override
+  List<int> encode(int fieldNumber) {
+    return ProtobufBytes(bytes).encode(fieldNumber);
+  }
+
+  /// Returns the Bech32 encoded address as a string.
+  String get value => Bech32Codec.encode(Bech32Pair(hrp: hrp, data: bytes));
+
+  @override
+  List<Object?> get props => <Object?>[hrp, bytes];
+
+  @override
+  String toString() => value;
+}

--- a/lib/src/transactions/cosmos/cosmos_auth_info.dart
+++ b/lib/src/transactions/cosmos/cosmos_auth_info.dart
@@ -1,0 +1,48 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/src/transactions/cosmos/cosmos_fee.dart';
+import 'package:cryptography_utils/src/transactions/cosmos/cosmos_signer_info.dart';
+
+/// [CosmosAuthInfo] describes the fee and signer modes that are used to sign a transaction.
+///
+/// https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/tx/v1beta1/tx.proto#L148
+class CosmosAuthInfo extends AProtobufObject {
+  /// Defines the signing modes for the required signers.
+  /// The number and order of elements must match the required signers from TxBody's messages.
+  /// The first element is the primary signer and the one which pays the fee.
+  final List<CosmosSignerInfo> signerInfos;
+
+  /// Defines the fee and gas limit for the transaction. The first signer is the
+  /// primary signer and the one which pays the fee. The fee can be calculated
+  /// based on the cost of evaluating the body and doing signature verification
+  /// of the signers. This can be estimated via simulation.
+  final CosmosFee fee;
+
+  /// Constructs an [CosmosAuthInfo] with the provided signer infos and fee.
+  const CosmosAuthInfo({
+    required this.signerInfos,
+    required this.fee,
+  });
+
+  /// Converts the object to a list of bytes compatible with Protobuf.
+  @override
+  Uint8List toProtoBytes() {
+    return ProtobufEncoder.encode(<int, AProtobufField>{
+      1: ProtobufList(signerInfos),
+      2: fee,
+    });
+  }
+
+  /// Converts the object to a JSON object compatible with Protobuf.
+  @override
+  Map<String, dynamic> toProtoJson() {
+    return <String, dynamic>{
+      'signer_infos': signerInfos.map((CosmosSignerInfo e) => e.toProtoJson()).toList(),
+      'fee': fee.toProtoJson(),
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[signerInfos, fee];
+}

--- a/lib/src/transactions/cosmos/cosmos_coin.dart
+++ b/lib/src/transactions/cosmos/cosmos_coin.dart
@@ -1,0 +1,54 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+
+/// [CosmosCoin] defines a token with a denomination and an amount.
+///
+/// https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/base/v1beta1/coin.proto
+class CosmosCoin extends AProtobufObject {
+  /// Denomination of the token
+  final String denom;
+
+  /// Amount of the token
+  final BigInt amount;
+
+  /// Constructs a [CosmosCoin] with the provided denomination and amount.
+  CosmosCoin({
+    required this.denom,
+    required this.amount,
+  });
+
+  /// Creates a [CosmosCoin] from the provided proto JSON.
+  factory CosmosCoin.fromProtoJson(Map<String, dynamic> data) {
+    return CosmosCoin(
+      denom: data['denom'] as String,
+      amount: BigInt.parse(data['amount'] as String),
+    );
+  }
+
+  /// Converts the object to a list of bytes compatible with Protobuf.
+  @override
+  Uint8List toProtoBytes() {
+    return ProtobufEncoder.encode(<int, AProtobufField>{
+      1: ProtobufString(denom),
+      2: ProtobufString(amount.toString()),
+    });
+  }
+
+  /// Converts the object to a JSON object compatible with Protobuf.
+  @override
+  Map<String, dynamic> toProtoJson() {
+    return <String, dynamic>{
+      'denom': denom,
+      'amount': amount.toString(),
+    };
+  }
+
+  @override
+  String toString() {
+    return '$amount$denom';
+  }
+
+  @override
+  List<Object?> get props => <Object?>[denom, amount];
+}

--- a/lib/src/transactions/cosmos/cosmos_compact_bit_array.dart
+++ b/lib/src/transactions/cosmos/cosmos_compact_bit_array.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+
+/// [CosmosCompactBitArray] is an implementation of a space efficient bit array.
+/// This is used to ensure that the encoded data takes up a minimal amount of space after proto encoding.
+/// This is not thread safe, and is not intended for concurrent usage.
+///
+/// https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/crypto/multisig/v1beta1/multisig.proto#L20
+class CosmosCompactBitArray extends AProtobufObject {
+  /// The number of extra bits stored in the compact bit array.
+  final int extraBitsStored;
+
+  /// The byte elements of the compact bit array.
+  final Uint8List elems;
+
+  CosmosCompactBitArray({
+    required this.extraBitsStored,
+    required this.elems,
+  });
+
+  /// Converts the object to a list of bytes compatible with Protobuf.
+  @override
+  Uint8List toProtoBytes() {
+    return ProtobufEncoder.encode(<int, AProtobufField>{
+      1: ProtobufInt32(extraBitsStored),
+      2: ProtobufBytes(elems),
+    });
+  }
+
+  /// Converts the object to a JSON object compatible with Protobuf.
+  @override
+  Map<String, dynamic> toProtoJson() {
+    return <String, dynamic>{
+      'extra_bits_stored': extraBitsStored,
+      'elems': base64Encode(elems),
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[extraBitsStored, elems];
+}

--- a/lib/src/transactions/cosmos/cosmos_fee.dart
+++ b/lib/src/transactions/cosmos/cosmos_fee.dart
@@ -1,0 +1,59 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/src/transactions/cosmos/cosmos_coin.dart';
+
+/// [CosmosFee] includes the amount of coins paid in fees and the maximum gas to be used by the transaction.
+/// The ratio yields an effective "gasprice", which must be above some minimum to be accepted into the mempool.
+///
+/// https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/tx/v1beta1/tx.proto#L219
+class CosmosFee extends AProtobufObject {
+  /// The amount of coins to be paid as a fee
+  final List<CosmosCoin> amount;
+
+  /// The maximum gas that can be used in transaction processing before an out of gas error occurs
+  final BigInt gasLimit;
+
+  /// The payer of the fee, if specified. If unset, the first signer is responsible for paying the fees.
+  /// If set, the specified account must pay the fees. The payer must be a tx signer (and thus have signed this field in AuthInfo).
+  /// Setting this field does *not* change the ordering of required signers for the transaction.
+  final String? payer;
+
+  /// The granter of the fee, if specified. If set, the fee payer (either the first signer or the value of the payer field) requests
+  /// that a fee grant be used to pay fees instead of the fee payer's own balance.
+  /// If an appropriate fee grant does not exist or the chain does not support fee grants, this will fail.
+  final String? granter;
+
+  /// Constructs a [CosmosFee] with the provided amount, gas limit, payer, and granter.
+  CosmosFee({
+    required this.amount,
+    required this.gasLimit,
+    this.payer,
+    this.granter,
+  });
+
+  /// Converts the object to a list of bytes compatible with Protobuf.
+  @override
+  Uint8List toProtoBytes() {
+    return ProtobufEncoder.encode(<int, AProtobufField?>{
+      1: ProtobufList(amount),
+      2: ProtobufInt64(gasLimit),
+      3: payer != null ? ProtobufString(payer!) : null,
+      4: granter != null ? ProtobufString(granter!) : null,
+    });
+  }
+
+  /// Converts the object to a JSON object compatible with Protobuf.
+  @override
+  Map<String, dynamic> toProtoJson() {
+    return <String, dynamic>{
+      'amount': amount.map((CosmosCoin e) => e.toProtoJson()).toList(),
+      'gas_limit': gasLimit.toString(),
+      'payer': payer,
+      'granter': granter,
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[amount, gasLimit, payer, granter];
+}

--- a/lib/src/transactions/cosmos/cosmos_sign_doc.dart
+++ b/lib/src/transactions/cosmos/cosmos_sign_doc.dart
@@ -1,0 +1,50 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/src/transactions/cosmos/cosmos_auth_info.dart';
+import 'package:cryptography_utils/src/transactions/cosmos/cosmos_tx_body.dart';
+import 'package:equatable/equatable.dart';
+
+/// [CosmosSignDoc] is the type used for generating sign bytes for SIGN_MODE_DIRECT
+///
+/// https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/tx/v1beta1/tx.proto#L51
+class CosmosSignDoc with EquatableMixin {
+  /// The processable content of the transaction.
+  final CosmosTxBody txBody;
+
+  /// The authorization related content of the transaction, specifically signers, signer modes and fee.
+  final CosmosAuthInfo authInfo;
+
+  /// The identifier of the chain this transaction targets.
+  /// It prevents signed transactions from being used on another chain by an attacker.
+  final String chainId;
+
+  /// The account number of the account in state.
+  final int accountNumber;
+
+  /// Constructs a [CosmosSignDoc] with the provided values.
+  CosmosSignDoc({
+    required this.txBody,
+    required this.authInfo,
+    required this.chainId,
+    required this.accountNumber,
+  });
+
+  /// Converts the object to a list of bytes compatible with Protobuf.
+  Uint8List toProtoBytes() {
+    return ProtobufEncoder.encode(<int, AProtobufField>{
+      1: txBody,
+      2: authInfo,
+      3: ProtobufString(chainId),
+      4: ProtobufInt32(accountNumber),
+    });
+  }
+
+  /// Returns the sign bytes for SIGN_MODE_DIRECT
+  Uint8List getDirectSignBytes() {
+    return toProtoBytes();
+  }
+
+  @override
+  List<Object?> get props => <Object?>[txBody, authInfo, chainId, accountNumber];
+}

--- a/lib/src/transactions/cosmos/cosmos_sign_mode.dart
+++ b/lib/src/transactions/cosmos/cosmos_sign_mode.dart
@@ -1,0 +1,74 @@
+import 'package:codec_utils/codec_utils.dart';
+
+/// SignMode represents a signing mode with its own security guarantees.
+
+/// This enum should be considered a registry of all known sign modes in the Cosmos ecosystem.
+/// Apps are not expected to support all known sign modes. Apps that would like to support custom
+/// sign modes are encouraged to open a small PR against this file to add a new case to this SignMode
+/// enum describing their sign mode so that different apps have a consistent version of this enum.
+///
+/// https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/tx/signing/v1beta1/signing.proto
+class CosmosSignMode extends ProtobufEnum {
+  const CosmosSignMode._(super.value, super.name);
+
+  /// sign-mode-unspecified specifies an unknown signing mode and will be
+  /// rejected.
+  static const CosmosSignMode signModeUnspecified = CosmosSignMode._(0, 'SIGN_MODE_UNSPECIFIED');
+
+  /// sign-mode-direct specifies a signing mode which uses SignDoc and is
+  /// verified with raw bytes from Tx.
+  static const CosmosSignMode signModeDirect = CosmosSignMode._(1, 'SIGN_MODE_DIRECT');
+
+  /// sign-mode-textual is a future signing mode that will verify some
+  /// human-readable textual representation on top of the binary representation
+  /// from sign-mode-direct.
+  ///
+  /// Since: cosmos-sdk 0.50
+  static const CosmosSignMode signModeTextual = CosmosSignMode._(2, 'SIGN_MODE_TEXTUAL');
+
+  /// sign-mode-direct-aux specifies a signing mode which uses
+  /// SignDocDirectAux. As opposed to sign-mode-direct, this sign mode does not
+  /// require signers signing over other signers' `signer_info`.
+  ///
+  /// Since: cosmos-sdk 0.46
+  static const CosmosSignMode signModeDirectAux = CosmosSignMode._(3, 'SIGN_MODE_DIRECT_AUX');
+
+  /// sign-mode-legacy-amino-json is a backwards compatibility mode which uses
+  /// Amino JSON and will be removed in the future.
+  static const CosmosSignMode signModeLegacyAminoJson = CosmosSignMode._(127, 'SIGN_MODE_LEGACY_AMINO_JSON');
+
+  /// sign-mode-eip-191 specifies the sign mode for EIP 191 signing on the Cosmos
+  /// SDK. Ref: https://eips.ethereum.org/EIPS/eip-191
+  ///
+  /// Currently, sign-mode-eip-191 is registered as a SignMode enum variant,
+  /// but is not implemented on the SDK by default. To enable EIP-191, you need
+  /// to pass a custom `TxConfig` that has an implementation of
+  /// `SignModeHandler` for EIP-191. The SDK may decide to fully support
+  /// EIP-191 in the future.
+  ///
+  /// Since: cosmos-sdk 0.45.2
+  /// Deprecated: post 0.47.x Sign mode refers to a method of encoding string data for
+  /// signing, but in the SDK, it also refers to how to encode a transaction into a string.
+  /// This opens the possibility for additional EIP191 sign modes, like sign-mode-eip-191-textual,
+  /// sign-mode-eip-191-legacy-json, and more.
+  /// Each new EIP191 sign mode should be accompanied by an associated ADR.
+  static const CosmosSignMode signModeEip191 = CosmosSignMode._(191, 'SIGN_MODE_EIP_191');
+
+  /// Returns a list of all available [CosmosSignMode] values.
+  static const List<CosmosSignMode> values = <CosmosSignMode>[
+    signModeUnspecified,
+    signModeDirect,
+    signModeTextual,
+    signModeDirectAux,
+    signModeLegacyAminoJson,
+    signModeEip191
+  ];
+
+  /// Returns the value of the enum from integer.
+  static CosmosSignMode fromValue(int? value) {
+    return values.firstWhere(
+      (CosmosSignMode element) => element.value == value,
+      orElse: () => throw const FormatException('No matching element found for the given value'),
+    );
+  }
+}

--- a/lib/src/transactions/cosmos/cosmos_signer_info.dart
+++ b/lib/src/transactions/cosmos/cosmos_signer_info.dart
@@ -1,0 +1,51 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/src/transactions/cosmos/mode_info/cosmos_mode_info.dart';
+import 'package:cryptography_utils/src/transactions/cosmos/public_key/cosmos_public_key.dart';
+
+/// [CosmosSignerInfo] describes the public key and signing mode of a single top-level signer.
+///
+/// https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/tx/v1beta1/tx.proto#L169
+class CosmosSignerInfo extends AProtobufObject {
+  /// The public key of the signer. It is optional for accounts that already exist in state.
+  /// If unset, the verifier can use the required signer address for this position and lookup the public key.
+  final CosmosPublicKey publicKey;
+
+  /// Describes the signing mode of the signer and is a nested structure to support nested multisig pubkey's
+  final CosmosModeInfo modeInfo;
+
+  /// Sequence of the account, which describes the number of committed transactions signed by a given address.
+  /// It is used to prevent replay attacks.
+  final int sequence;
+
+  /// Constructs a [CosmosSignerInfo] with the provided public key, mode info, and sequence.
+  const CosmosSignerInfo({
+    required this.publicKey,
+    required this.modeInfo,
+    required this.sequence,
+  });
+
+  /// Converts the object to a list of bytes compatible with Protobuf.
+  @override
+  Uint8List toProtoBytes() {
+    return ProtobufEncoder.encode(<int, AProtobufField?>{
+      1: publicKey,
+      2: modeInfo,
+      3: ProtobufInt32(sequence),
+    });
+  }
+
+  /// Converts the object to a JSON object compatible with Protobuf.
+  @override
+  Map<String, dynamic> toProtoJson() {
+    return <String, dynamic>{
+      'public_key': publicKey.toProtoJson(),
+      'mode_info': modeInfo.toProtoJson(),
+      'sequence': sequence.toString(),
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object>[publicKey, modeInfo, sequence];
+}

--- a/lib/src/transactions/cosmos/cosmos_tx.dart
+++ b/lib/src/transactions/cosmos/cosmos_tx.dart
@@ -1,0 +1,61 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:crypto/crypto.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// [CosmosTx] is the standard type used for broadcasting transactions.
+///
+/// https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/tx/v1beta1/tx.proto#L16
+class CosmosTx extends AProtobufObject {
+  /// The processable content of the transaction
+  final CosmosTxBody body;
+
+  /// the authorization related content of the transaction, specifically signers, signer modes and fee
+  final CosmosAuthInfo authInfo;
+
+  /// List of signatures that matches the length and order of [CosmosAuthInfo]'s [signerInfos]
+  /// to allow connecting signature meta information like public key and signing mode by position.
+  final List<CosmosSignature> signatures;
+
+  /// Constructs a [CosmosTx] with the provided body, auth info, and signatures.
+  CosmosTx.signed({
+    required this.body,
+    required this.authInfo,
+    required this.signatures,
+  });
+
+  /// Constructs a [CosmosTx] with the provided body and auth info.
+  CosmosTx.unsigned({
+    required this.body,
+    required this.authInfo,
+  }) : signatures = const <CosmosSignature>[];
+
+  /// Converts the object to a list of bytes compatible with Protobuf.
+  @override
+  Uint8List toProtoBytes() {
+    return ProtobufEncoder.encode(<int, AProtobufField>{
+      1: body,
+      2: authInfo,
+      3: ProtobufList(signatures.map((CosmosSignature e) => ProtobufBytes(e.bytes)).toList()),
+    });
+  }
+
+  /// Converts the object to a JSON object compatible with Protobuf.
+  @override
+  Map<String, dynamic> toProtoJson() {
+    return <String, dynamic>{
+      'body': body.toProtoJson(),
+      'auth_info': authInfo.toProtoJson(),
+      'signatures': signatures.map((CosmosSignature e) => e.base64).toList(),
+    };
+  }
+
+  /// Returns the transaction hash.
+  String getTransactionHash() {
+    return HexCodec.encode(sha256.convert(toProtoBytes()).bytes, includePrefixBool: true);
+  }
+
+  @override
+  List<Object?> get props => <Object?>[body, authInfo, signatures];
+}

--- a/lib/src/transactions/cosmos/cosmos_tx_body.dart
+++ b/lib/src/transactions/cosmos/cosmos_tx_body.dart
@@ -1,0 +1,82 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// [CosmosTxBody] is the body of a transaction that all signers sign over.
+///
+/// https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/tx/v1beta1/tx.proto#L96
+class CosmosTxBody extends AProtobufObject {
+  /// List of messages to be executed. The required signers of those messages define the number and order
+  /// of elements in [CosmosAuthInfo]'s [signerInfos] and [CosmosTx]'s signatures. Each required signer address is added to
+  /// the list only the first time it occurs. By convention, the first required signer (usually from the first message)
+  /// is referred to as the primary signer and pays the fee for the whole transaction.
+  final List<ProtobufAny> messages;
+
+  /// Defines any arbitrary note/comment to be added to the transaction.
+  /// WARNING: in clients, any publicly exposed text should not be called memo,
+  /// but should be called `note` instead (see https://github.com/cosmos/cosmos-sdk/issues/9122).
+  final String memo;
+
+  /// Defines the block height after which this transaction will not be processed by the chain.
+  /// Note, if unordered=true this value MUST be set and will act as a short-lived TTL
+  /// in which the transaction is deemed valid and kept in memory to prevent duplicates.
+  final BigInt timeoutHeight;
+
+  /// When set to true, indicates that the transaction signer(s)intend for the transaction
+  /// to be evaluated and executed in an un-ordered fashion. Specifically, the account's nonce will NOT be checked or
+  /// incremented, which allows for fire-and-forget as well as concurrent transaction execution.
+  ///
+  /// Note, when set to true, the existing 'timeout_height' value must be set and will be used
+  /// to correspond to a height in which the transaction is deemed valid.
+  final bool unordered;
+
+  /// Arbitrary options that can be added by chains when the default options are not sufficient.
+  /// If any of these are present and can't be handled, the transaction will be rejected
+  final List<ProtobufAny> extensionOptions;
+
+  /// Arbitrary options that can be added by chains when the default options are not sufficient.
+  /// If any of these are present and can't be handled, they will be ignored
+  final List<ProtobufAny> nonCriticalExtensionOptions;
+
+  /// Constructs a [CosmosTxBody] with the provided messages, memo, timeout height, extension options, and non-critical extension options.
+  CosmosTxBody({
+    required this.messages,
+    this.memo = '',
+    this.unordered = false,
+    BigInt? timeoutHeight,
+    List<ProtobufAny>? extensionOptions,
+    List<ProtobufAny>? nonCriticalExtensionOptions,
+  })  : timeoutHeight = timeoutHeight ?? BigInt.zero,
+        extensionOptions = extensionOptions ?? <ProtobufAny>[],
+        nonCriticalExtensionOptions = nonCriticalExtensionOptions ?? <ProtobufAny>[];
+
+  /// Converts the object to a list of bytes compatible with Protobuf.
+  @override
+  Uint8List toProtoBytes() {
+    return ProtobufEncoder.encode(<int, AProtobufField?>{
+      1: ProtobufList(messages),
+      2: ProtobufString(memo),
+      3: ProtobufInt64(timeoutHeight),
+      4: ProtobufBool(unordered),
+      1023: ProtobufList(extensionOptions),
+      2047: ProtobufList(nonCriticalExtensionOptions),
+    });
+  }
+
+  /// Converts the object to a JSON object compatible with Protobuf.
+  @override
+  Map<String, dynamic> toProtoJson() {
+    return <String, dynamic>{
+      'messages': messages.map((ProtobufAny e) => e.toProtoJson()).toList(),
+      'memo': memo,
+      'timeout_height': timeoutHeight.toString(),
+      if (unordered) 'unordered': unordered,
+      'extension_options': extensionOptions.map((ProtobufAny e) => e.toProtoJson()).toList(),
+      'non_critical_extension_options': nonCriticalExtensionOptions.map((ProtobufAny e) => e.toProtoJson()).toList(),
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object>[messages, memo, timeoutHeight, unordered, extensionOptions, nonCriticalExtensionOptions];
+}

--- a/lib/src/transactions/cosmos/mode_info/cosmos_mode_info.dart
+++ b/lib/src/transactions/cosmos/mode_info/cosmos_mode_info.dart
@@ -1,0 +1,52 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// [CosmosModeInfo] describes the signing mode of a single or nested multisig signer.
+///
+/// https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/tx/v1beta1/tx.proto#L186
+class CosmosModeInfo extends AProtobufObject {
+  /// Represents a single signer
+  final CosmosModeInfoSingle? single;
+
+  /// Represents a nested multisig signer
+  final CosmosModeInfoMulti? multi;
+
+  CosmosModeInfo._({
+    this.single,
+    this.multi,
+  });
+
+  /// Constructs a [CosmosModeInfo] with the provided single signer.
+  factory CosmosModeInfo.single(CosmosSignMode signMode) {
+    return CosmosModeInfo._(single: CosmosModeInfoSingle(signMode));
+  }
+
+  /// Constructs a [CosmosModeInfo] with the provided multi signer.
+  factory CosmosModeInfo.multi({required CosmosCompactBitArray bitArray, required List<CosmosModeInfo> modeInfos}) {
+    return CosmosModeInfo._(multi: CosmosModeInfoMulti(bitArray: bitArray, modeInfos: modeInfos));
+  }
+
+  /// Converts the object to a list of bytes compatible with Protobuf.
+  @override
+  Uint8List toProtoBytes() {
+    return ProtobufEncoder.encode(<int, AProtobufField?>{
+      1: single,
+      2: multi,
+    });
+  }
+
+  /// Converts the object to a JSON object compatible with Protobuf.
+  @override
+  Map<String, dynamic> toProtoJson() {
+    if (single != null) {
+      return <String, dynamic>{'single': single?.toProtoJson()};
+    } else {
+      return <String, dynamic>{'multi': multi?.toProtoJson()};
+    }
+  }
+
+  @override
+  List<Object?> get props => <Object?>[single, multi];
+}

--- a/lib/src/transactions/cosmos/mode_info/cosmos_mode_info_multi.dart
+++ b/lib/src/transactions/cosmos/mode_info/cosmos_mode_info_multi.dart
@@ -1,0 +1,42 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// Mode info for a multisig public key
+///
+/// https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/tx/v1beta1/tx.proto#L206
+class CosmosModeInfoMulti extends AProtobufObject {
+  /// Specifies which keys within the multisig are signing
+  final CosmosCompactBitArray bitArray;
+
+  /// Modes of the signers of the multisig which could include nested multisig public keys
+  final List<CosmosModeInfo> modeInfos;
+
+  /// Constructs a [CosmosModeInfoMulti] with the provided bit array and mode infos.
+  CosmosModeInfoMulti({
+    required this.bitArray,
+    required this.modeInfos,
+  });
+
+  /// Converts the object to a list of bytes compatible with Protobuf.
+  @override
+  Uint8List toProtoBytes() {
+    return ProtobufEncoder.encode(<int, AProtobufField>{
+      1: bitArray,
+      2: ProtobufList(modeInfos),
+    });
+  }
+
+  /// Converts the object to a JSON object compatible with Protobuf.
+  @override
+  Map<String, dynamic> toProtoJson() {
+    return <String, dynamic>{
+      'bitarray': bitArray.toProtoJson(),
+      'mode_infos': modeInfos.map((CosmosModeInfo e) => e.toProtoJson()).toList(),
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[bitArray, modeInfos];
+}

--- a/lib/src/transactions/cosmos/mode_info/cosmos_mode_info_single.dart
+++ b/lib/src/transactions/cosmos/mode_info/cosmos_mode_info_single.dart
@@ -1,0 +1,33 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// Mode info for a single signer. It is structured as a message to allow
+/// for additional fields such as locale for SIGN_MODE_TEXTUAL in the future
+///
+/// https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/tx/v1beta1/tx.proto#L200
+class CosmosModeInfoSingle extends AProtobufObject {
+  /// Signing mode of the single signer
+  final CosmosSignMode signMode;
+
+  /// Constructs a [CosmosModeInfoSingle] with the provided signing mode.
+  CosmosModeInfoSingle(this.signMode);
+
+  /// Converts the object to a list of bytes compatible with Protobuf.
+  @override
+  Uint8List toProtoBytes() {
+    return ProtobufEncoder.encode(<int, AProtobufField>{
+      1: signMode,
+    });
+  }
+
+  /// Converts the object to a JSON object compatible with Protobuf.
+  @override
+  Map<String, dynamic> toProtoJson() {
+    return <String, dynamic>{'mode': signMode.name};
+  }
+
+  @override
+  List<Object?> get props => <Object?>[signMode];
+}

--- a/lib/src/transactions/cosmos/public_key/cosmos_legacy_amino_multisig_public_key.dart
+++ b/lib/src/transactions/cosmos/public_key/cosmos_legacy_amino_multisig_public_key.dart
@@ -1,0 +1,43 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// [CosmosLegacyAminoMultisigPublicKey] specifies a public key type which nests multiple public keys and a threshold, it uses legacy amino address rules.
+///
+/// https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/crypto/multisig/keys.proto#L13
+class CosmosLegacyAminoMultisigPublicKey extends CosmosPublicKey {
+  /// The threshold number of signatures required for the multisig public key.
+  final int threshold;
+
+  /// The list of simple public keys involved in the multisig.
+  final List<CosmosSimplePublicKey> publicKeys;
+
+  /// Constructs a [CosmosLegacyAminoMultisigPublicKey] with the given key.
+  const CosmosLegacyAminoMultisigPublicKey({
+    required this.threshold,
+    required this.publicKeys,
+  }) : super(typeUrl: '/cosmos.crypto.multisig.LegacyAminoPubKey');
+
+  /// Converts the object to a list of bytes compatible with Protobuf.
+  @override
+  Uint8List toProtoBytes() {
+    return ProtobufEncoder.encode(<int, AProtobufField?>{
+      1: ProtobufInt32(threshold),
+      2: ProtobufList(publicKeys),
+    });
+  }
+
+  /// Converts the object to a JSON object compatible with Protobuf.
+  @override
+  Map<String, dynamic> toProtoJson() {
+    return <String, dynamic>{
+      '@type': typeUrl,
+      'threshold': threshold,
+      'public_keys': publicKeys.map((CosmosSimplePublicKey e) => e.toProtoJson()).toList(),
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object>[threshold, publicKeys];
+}

--- a/lib/src/transactions/cosmos/public_key/cosmos_public_key.dart
+++ b/lib/src/transactions/cosmos/public_key/cosmos_public_key.dart
@@ -1,0 +1,9 @@
+import 'package:codec_utils/codec_utils.dart';
+
+/// [CosmosPublicKey] is the abstract class that wraps the public key type.
+abstract class CosmosPublicKey extends ProtobufAny {
+  /// Constructs a [CosmosPublicKey]
+  const CosmosPublicKey({
+    required super.typeUrl,
+  });
+}

--- a/lib/src/transactions/cosmos/public_key/cosmos_simple_public_key.dart
+++ b/lib/src/transactions/cosmos/public_key/cosmos_simple_public_key.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// Data object holding the SIMPLE public key component of an account or signature.
+///
+/// https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/crypto/secp256k1/keys.proto#L14
+class CosmosSimplePublicKey extends CosmosPublicKey {
+  /// Represents public key bytes.
+  final Uint8List key;
+
+  /// Constructs a [CosmosSimplePublicKey] with the given key.
+  const CosmosSimplePublicKey(this.key) : super(typeUrl: '/cosmos.crypto.secp256k1.PubKey');
+
+  /// Converts the object to a list of bytes compatible with Protobuf.
+  @override
+  Uint8List toProtoBytes() {
+    return ProtobufEncoder.encode(<int, AProtobufField>{
+      1: ProtobufBytes(key),
+    });
+  }
+
+  /// Converts the object to a JSON object compatible with Protobuf.
+  @override
+  Map<String, dynamic> toProtoJson() {
+    return <String, dynamic>{
+      '@type': typeUrl,
+      'key': base64Encode(key),
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object>[key];
+}

--- a/lib/src/transactions/cosmos/public_key/cosmos_val_cons_public_key.dart
+++ b/lib/src/transactions/cosmos/public_key/cosmos_val_cons_public_key.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// Data object holding the public key component of a validator's account or signature.
+/// Identifies validator nodes that are participating in consensus.
+///
+/// https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/crypto/ed25519/keys.proto#L14
+class CosmosValConsPublicKey extends CosmosPublicKey {
+  /// Represents public key bytes.
+  final Uint8List key;
+
+  /// Constructs a [CosmosValConsPublicKey] with the given key.
+  const CosmosValConsPublicKey(this.key) : super(typeUrl: '/cosmos.crypto.ed25519.PubKey');
+
+  /// Converts the object to a list of bytes compatible with Protobuf.
+  @override
+  Uint8List toProtoBytes() {
+    return ProtobufEncoder.encode(<int, AProtobufField>{
+      1: ProtobufBytes(key),
+    });
+  }
+
+  @override
+  Map<String, dynamic> toProtoJson() {
+    return <String, dynamic>{
+      '@type': typeUrl,
+      'key': base64Encode(key),
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object>[key];
+}

--- a/lib/src/transactions/export.dart
+++ b/lib/src/transactions/export.dart
@@ -1,7 +1,29 @@
+// Cosmos
+export 'cosmos/cosmos_acc_address.dart';
+export 'cosmos/cosmos_auth_info.dart';
+export 'cosmos/cosmos_coin.dart';
+export 'cosmos/cosmos_compact_bit_array.dart';
+export 'cosmos/cosmos_fee.dart';
+export 'cosmos/cosmos_sign_doc.dart';
+export 'cosmos/cosmos_sign_mode.dart';
+export 'cosmos/cosmos_signer_info.dart';
+export 'cosmos/cosmos_tx.dart';
+export 'cosmos/cosmos_tx_body.dart';
+export 'cosmos/mode_info/cosmos_mode_info.dart';
+export 'cosmos/mode_info/cosmos_mode_info_multi.dart';
+export 'cosmos/mode_info/cosmos_mode_info_single.dart';
+export 'cosmos/public_key/cosmos_legacy_amino_multisig_public_key.dart';
+export 'cosmos/public_key/cosmos_public_key.dart';
+export 'cosmos/public_key/cosmos_simple_public_key.dart';
+export 'cosmos/public_key/cosmos_val_cons_public_key.dart';
+
+// Ethereum
 export 'ethereum/a_ethereum_transaction.dart';
 export 'ethereum/access_list_bytes_item.dart';
 export 'ethereum/ethereum_eip1559_transaction.dart';
 export 'ethereum/ethereum_raw_bytes_transaction.dart';
+
+// Generic
 export 'sign_data_type.dart';
 export 'token_amount.dart';
 export 'token_denomination_type.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cryptography_utils
 description: "Dart package containing utility methods for common cryptographic and blockchain-specific operations"
 publish_to: none
-version: 0.0.18
+version: 0.0.19
 
 environment:
   sdk: ">=3.2.6"

--- a/test/signer/cosmos/cosmos_signature_test.dart
+++ b/test/signer/cosmos/cosmos_signature_test.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+
+import 'package:cryptography_utils/src/signer/cosmos/cosmos_signature.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of CosmosSignature.bytes getter', () {
+    test('Should [return bytes] representing Cosmos signature', () {
+      // Arrange
+      CosmosSignature actualCosmosSignature = CosmosSignature(
+        s: BigInt.parse('25762741804310061202983426251141315765040090201449012852222856059029735330091'),
+        r: BigInt.parse('38405229888052653976493395571873434429328497679884784055390575135932131163697'),
+      );
+
+      // Act
+      List<int> actualBytes = actualCosmosSignature.bytes;
+
+      // Assert
+      List<int> expectedBytes = base64Decode('VOiW/TF7pRINaMatMux1KZP3GRiXkAbvXdoQEQr1vjE49THzl1gerUme+MsMjIBoWw9LUiMc6T/NfnLhr1vRKw==');
+
+      expect(actualBytes, expectedBytes);
+    });
+  });
+
+  group('Tests of CosmosSignature.base64 getter', () {
+    test('Should [return base64 string] representing Cosmos signature', () {
+      // Arrange
+      CosmosSignature actualCosmosSignature = CosmosSignature(
+        s: BigInt.parse('25762741804310061202983426251141315765040090201449012852222856059029735330091'),
+        r: BigInt.parse('38405229888052653976493395571873434429328497679884784055390575135932131163697'),
+      );
+
+      // Act
+      String actualBase64 = actualCosmosSignature.base64;
+
+      // Assert
+      String expectedBase64 = 'VOiW/TF7pRINaMatMux1KZP3GRiXkAbvXdoQEQr1vjE49THzl1gerUme+MsMjIBoWw9LUiMc6T/NfnLhr1vRKw==';
+
+      expect(actualBase64, expectedBase64);
+    });
+  });
+
+  group('Tests of CosmosSignature.hex getter', () {
+    test('Should [return HEX string] representing Cosmos signature', () {
+      // Arrange
+      CosmosSignature actualCosmosSignature = CosmosSignature(
+        s: BigInt.parse('25762741804310061202983426251141315765040090201449012852222856059029735330091'),
+        r: BigInt.parse('38405229888052653976493395571873434429328497679884784055390575135932131163697'),
+      );
+
+      // Act
+      String actualHex = actualCosmosSignature.hex;
+
+      // Assert
+      String expectedHex = '0x54e896fd317ba5120d68c6ad32ec752993f71918979006ef5dda10110af5be3138f531f397581ead499ef8cb0c8c80685b0f4b52231ce93fcd7e72e1af5bd12b';
+
+      expect(actualHex, expectedHex);
+    });
+  });
+
+  group('Tests of CosmosSignature.length getter', () {
+    test('Should [return length] of  Cosmos signature', () {
+      // Arrange
+      CosmosSignature actualCosmosSignature = CosmosSignature(
+        s: BigInt.parse('25762741804310061202983426251141315765040090201449012852222856059029735330091'),
+        r: BigInt.parse('38405229888052653976493395571873434429328497679884784055390575135932131163697'),
+      );
+
+      // Act
+      int actualLength = actualCosmosSignature.length;
+
+      // Assert
+      int expectedLength = 64;
+
+      expect(actualLength, expectedLength);
+    });
+  });
+}

--- a/test/signer/cosmos/cosmos_signer_test.dart
+++ b/test/signer/cosmos/cosmos_signer_test.dart
@@ -1,0 +1,60 @@
+import 'dart:convert';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+import '../../transactions/cosmos/test_data/test_msg_send.dart';
+
+void main() {
+  CosmosSigner actualCosmosSigner = CosmosSigner(ECPrivateKey.fromBytes(
+    base64Decode('OVXyPYAZbAQFwsUfHLEk64sYnyy8OThTIWCC82Iir7U='),
+    CurvePoints.generatorSecp256k1,
+  ));
+
+  group('Tests of CosmosSigner.signDirect()', () {
+    test('Should [return CosmosSignature] representing proof of signing CosmosSignDoc with given private key ', () {
+      // Arrange
+      CosmosSignDoc actualCosmosSignDoc = CosmosSignDoc(
+        chainId: 'testnet-1',
+        accountNumber: 4,
+        authInfo: CosmosAuthInfo(
+          signerInfos: <CosmosSignerInfo>[
+            CosmosSignerInfo(
+              publicKey: CosmosSimplePublicKey(base64Decode('AlLas8CJ6lm5yZJ8h0U5Qu9nzVvgvskgHuURPB3jvUx8')),
+              modeInfo: CosmosModeInfo.single(CosmosSignMode.signModeDirect),
+              sequence: 27,
+            ),
+          ],
+          fee: CosmosFee(
+            gasLimit: BigInt.from(20000),
+            amount: <CosmosCoin>[CosmosCoin(denom: 'ukex', amount: BigInt.from(100))],
+          ),
+        ),
+        txBody: CosmosTxBody(
+          messages: <ProtobufAny>[
+            TestMsgSend(
+              fromAddress: 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+              toAddress: 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+              amount: <CosmosCoin>[
+                CosmosCoin(denom: 'ukex', amount: BigInt.from(12)),
+              ],
+            ),
+          ],
+          memo: '123123',
+        ),
+      );
+
+      // Act
+      CosmosSignature actualCosmosSignature = actualCosmosSigner.signDirect(actualCosmosSignDoc);
+
+      // Assert
+      CosmosSignature expectedCosmosSignature = CosmosSignature(
+        s: BigInt.parse('25762741804310061202983426251141315765040090201449012852222856059029735330091'),
+        r: BigInt.parse('38405229888052653976493395571873434429328497679884784055390575135932131163697'),
+      );
+
+      expect(actualCosmosSignature, expectedCosmosSignature);
+    });
+  });
+}

--- a/test/signer/cosmos/cosmos_verifier_test.dart
+++ b/test/signer/cosmos/cosmos_verifier_test.dart
@@ -1,0 +1,80 @@
+import 'dart:convert';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+import '../../transactions/cosmos/test_data/test_msg_send.dart';
+
+void main() {
+  CosmosVerifier actualCosmosVerifier = CosmosVerifier(ECPublicKey(
+    CurvePoints.generatorSecp256k1,
+    ECPoint(
+      curve: CurvePoints.generatorSecp256k1.curve,
+      n: BigInt.parse('115792089237316195423570985008687907852837564279074904382605163141518161494337'),
+      x: BigInt.parse('103541830980023606809613093633067363502594290705821036222890728111110906420509'),
+      y: BigInt.parse('75808906644622006047938879719654783679105512040910575915102508326553703647166'),
+      z: BigInt.parse('3190226348536498292494465017020441737630476122313049345633869118655223224149'),
+    ),
+  ));
+
+  CosmosSignDoc actualCosmosSignDoc = CosmosSignDoc(
+    chainId: 'testnet-1',
+    accountNumber: 4,
+    authInfo: CosmosAuthInfo(
+      signerInfos: <CosmosSignerInfo>[
+        CosmosSignerInfo(
+          publicKey: CosmosSimplePublicKey(base64Decode('AlLas8CJ6lm5yZJ8h0U5Qu9nzVvgvskgHuURPB3jvUx8')),
+          modeInfo: CosmosModeInfo.single(CosmosSignMode.signModeDirect),
+          sequence: 27,
+        ),
+      ],
+      fee: CosmosFee(
+        gasLimit: BigInt.from(20000),
+        amount: <CosmosCoin>[CosmosCoin(denom: 'ukex', amount: BigInt.from(100))],
+      ),
+    ),
+    txBody: CosmosTxBody(
+      messages: <ProtobufAny>[
+        TestMsgSend(
+          fromAddress: 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+          toAddress: 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+          amount: <CosmosCoin>[
+            CosmosCoin(denom: 'ukex', amount: BigInt.from(12)),
+          ],
+        ),
+      ],
+      memo: '123123',
+    ),
+  );
+
+  group('Tests of CosmosVerifier.isSignatureValid()', () {
+    test('Should [return TRUE] if [signature VALID]', () {
+      // Arrange
+      CosmosSignature actualCosmosSignature = CosmosSignature(
+        s: BigInt.parse('25762741804310061202983426251141315765040090201449012852222856059029735330091'),
+        r: BigInt.parse('38405229888052653976493395571873434429328497679884784055390575135932131163697'),
+      );
+
+      // Act
+      bool actualSignatureValidBool = actualCosmosVerifier.isSignatureValid(actualCosmosSignDoc, actualCosmosSignature);
+
+      // Assert
+      expect(actualSignatureValidBool, true);
+    });
+
+    test('Should [return FALSE] if [signature INVALID]', () {
+      // Arrange
+      CosmosSignature actualCosmosSignature = CosmosSignature(
+        s: BigInt.parse('6835855700083175663074049776142580319076931796729422201778649332595916663970'),
+        r: BigInt.parse('32362148283266006124111739650771005129442507022876757984837887947616516157578'),
+      );
+
+      // Act
+      bool actualSignatureValidBool = actualCosmosVerifier.isSignatureValid(actualCosmosSignDoc, actualCosmosSignature);
+
+      // Assert
+      expect(actualSignatureValidBool, false);
+    });
+  });
+}

--- a/test/transactions/cosmos/cosmos_auth_info_test.dart
+++ b/test/transactions/cosmos/cosmos_auth_info_test.dart
@@ -1,0 +1,84 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of CosmosAuthInfo.toProtoBytes()', () {
+    test('Should [return protobuf bytes] representing CosmosAuthInfo', () {
+      // Arrange
+      CosmosAuthInfo actualCosmosAuthInfo = CosmosAuthInfo(
+        signerInfos: <CosmosSignerInfo>[
+          CosmosSignerInfo(
+            publicKey: CosmosSimplePublicKey(base64Decode('CiECUtqzwInqWbnJknyHRTlC72fNW+C+ySAe5RE8HeO9THw=')),
+            modeInfo: CosmosModeInfo.single(CosmosSignMode.signModeDirect),
+            sequence: 34,
+          ),
+        ],
+        fee: CosmosFee(
+          gasLimit: BigInt.parse('20000'),
+          amount: <CosmosCoin>[CosmosCoin(denom: 'ukex', amount: BigInt.parse('100'))],
+        ),
+      );
+
+      // Act
+      Uint8List actualProtoBytes = actualCosmosAuthInfo.toProtoBytes();
+
+      // Assert
+      Uint8List expectedProtoBytes = base64Decode(
+        'ClIKSAofL2Nvc21vcy5jcnlwdG8uc2VjcDI1NmsxLlB1YktleRIlCiMKIQJS2rPAiepZucmSfIdFOULvZ81b4L7JIB7lETwd471MfBIECgIIARgiEhEKCwoEdWtleBIDMTAwEKCcAQ==',
+      );
+
+      expect(actualProtoBytes, expectedProtoBytes);
+    });
+  });
+
+  group('Tests of CosmosAuthInfo.toProtoJson()', () {
+    test('Should [return JSON] representing CosmosAuthInfo', () {
+      // Arrange
+      CosmosAuthInfo actualCosmosAuthInfo = CosmosAuthInfo(
+        signerInfos: <CosmosSignerInfo>[
+          CosmosSignerInfo(
+            publicKey: CosmosSimplePublicKey(base64Decode('CiECUtqzwInqWbnJknyHRTlC72fNW+C+ySAe5RE8HeO9THw=')),
+            modeInfo: CosmosModeInfo.single(CosmosSignMode.signModeDirect),
+            sequence: 34,
+          ),
+        ],
+        fee: CosmosFee(
+          gasLimit: BigInt.parse('20000'),
+          amount: <CosmosCoin>[CosmosCoin(denom: 'ukex', amount: BigInt.parse('100'))],
+        ),
+      );
+
+      // Act
+      Map<String, dynamic> actualData = actualCosmosAuthInfo.toProtoJson();
+
+      // Assert
+      Map<String, dynamic> expectedData = <String, dynamic>{
+        'signer_infos': <Map<String, Object>>[
+          <String, Object>{
+            'public_key': <String, String>{
+              '@type': '/cosmos.crypto.secp256k1.PubKey',
+              'key': 'CiECUtqzwInqWbnJknyHRTlC72fNW+C+ySAe5RE8HeO9THw=',
+            },
+            'mode_info': <String, Map<String, String>>{
+              'single': <String, String>{'mode': 'SIGN_MODE_DIRECT'}
+            },
+            'sequence': '34',
+          }
+        ],
+        'fee': <String, Object?>{
+          'gas_limit': '20000',
+          'amount': <Map<String, String>>[
+            <String, String>{'denom': 'ukex', 'amount': '100'}
+          ],
+          'payer': null,
+          'granter': null,
+        }
+      };
+
+      expect(actualData, expectedData);
+    });
+  });
+}

--- a/test/transactions/cosmos/cosmos_coin_test.dart
+++ b/test/transactions/cosmos/cosmos_coin_test.dart
@@ -1,0 +1,39 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/src/transactions/cosmos/cosmos_coin.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of CosmosCoin.toProtoBytes()', () {
+    test('Should [return protobuf bytes] representing CosmosCoin', () {
+      // Arrange
+      CosmosCoin actualCosmosCoin = CosmosCoin(denom: 'ukex', amount: BigInt.parse('100'));
+
+      // Act
+      Uint8List actualProtoBytes = actualCosmosCoin.toProtoBytes();
+
+      // Assert
+      Uint8List expectedProtoBytes = Uint8List.fromList(<int>[10, 4, 117, 107, 101, 120, 18, 3, 49, 48, 48]);
+
+      expect(actualProtoBytes, expectedProtoBytes);
+    });
+  });
+
+  group('Tests of CosmosCoin.toData()', () {
+    test('Should [return JSON] representing CosmosCoin', () {
+      // Arrange
+      CosmosCoin actualCosmosCoin = CosmosCoin(denom: 'ukex', amount: BigInt.parse('100'));
+
+      // Act
+      Map<String, dynamic> actualData = actualCosmosCoin.toProtoJson();
+
+      // Assert
+      Map<String, dynamic> expectedData = <String, dynamic>{
+        'denom': 'ukex',
+        'amount': '100',
+      };
+
+      expect(actualData, expectedData);
+    });
+  });
+}

--- a/test/transactions/cosmos/cosmos_compact_bit_array_test.dart
+++ b/test/transactions/cosmos/cosmos_compact_bit_array_test.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of CosmosCompactBitArray.toProtoBytes()', () {
+    test('Should [return protobuf bytes] representing CosmosCompactBitArray', () {
+      // Arrange
+      CosmosCompactBitArray actualCosmosCompactBitArray = CosmosCompactBitArray(extraBitsStored: 1, elems: base64Decode('AQ=='));
+
+      // Act
+      Uint8List actualProtoBytes = actualCosmosCompactBitArray.toProtoBytes();
+
+      // Assert
+      Uint8List expectedProtoBytes = Uint8List.fromList(<int>[8, 1, 18, 1, 1]);
+
+      expect(actualProtoBytes, expectedProtoBytes);
+    });
+  });
+
+  group('Tests of CosmosCompactBitArray.toData()', () {
+    test('Should [return JSON] representing CosmosCompactBitArray', () {
+      // Arrange
+      CosmosCompactBitArray actualCosmosCompactBitArray = CosmosCompactBitArray(extraBitsStored: 1, elems: base64Decode('AQ=='));
+
+      // Act
+      Map<String, dynamic> actualData = actualCosmosCompactBitArray.toProtoJson();
+
+      // Assert
+      Map<String, dynamic> expectedData = <String, dynamic>{
+        'extra_bits_stored': 1,
+        'elems': 'AQ==',
+      };
+
+      expect(actualData, expectedData);
+    });
+  });
+}

--- a/test/transactions/cosmos/cosmos_fee_test.dart
+++ b/test/transactions/cosmos/cosmos_fee_test.dart
@@ -1,0 +1,49 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of CosmosFee.toProtoBytes()', () {
+    test('Should [return protobuf bytes] representing CosmosFee', () {
+      // Arrange
+      CosmosFee actualCosmosFee = CosmosFee(
+        gasLimit: BigInt.parse('20000'),
+        amount: <CosmosCoin>[CosmosCoin(denom: 'ukex', amount: BigInt.parse('100'))],
+      );
+
+      // Act
+      Uint8List actualProtoBytes = actualCosmosFee.toProtoBytes();
+
+      // Assert
+      Uint8List expectedProtoBytes = Uint8List.fromList(<int>[10, 11, 10, 4, 117, 107, 101, 120, 18, 3, 49, 48, 48, 16, 160, 156, 1]);
+
+      expect(actualProtoBytes, expectedProtoBytes);
+    });
+  });
+
+  group('Tests of CosmosFee.toProtoJson()', () {
+    test('Should [return JSON] representing CosmosFee', () {
+      // Arrange
+      CosmosFee actualCosmosFee = CosmosFee(
+        gasLimit: BigInt.parse('20000'),
+        amount: <CosmosCoin>[CosmosCoin(denom: 'ukex', amount: BigInt.parse('100'))],
+      );
+
+      // Act
+      Map<String, dynamic> actualData = actualCosmosFee.toProtoJson();
+
+      // Assert
+      Map<String, dynamic> expectedData = <String, dynamic>{
+        'gas_limit': '20000',
+        'amount': <Map<String, String>>[
+          <String, String>{'denom': 'ukex', 'amount': '100'}
+        ],
+        'payer': null,
+        'granter': null
+      };
+
+      expect(actualData, expectedData);
+    });
+  });
+}

--- a/test/transactions/cosmos/cosmos_sign_doc_test.dart
+++ b/test/transactions/cosmos/cosmos_sign_doc_test.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+import 'test_data/test_msg_send.dart';
+
+void main() {
+  group('Tests of CosmosSignDoc.toProtoBytes()', () {
+    test('Should [return protobuf bytes] representing CosmosSignDoc', () {
+      // Arrange
+      CosmosSignDoc actualCosmosSignDoc = CosmosSignDoc(
+        chainId: 'testnet-1',
+        accountNumber: 4,
+        authInfo: CosmosAuthInfo(
+          signerInfos: <CosmosSignerInfo>[
+            CosmosSignerInfo(
+              publicKey: CosmosSimplePublicKey(base64Decode('CiECUtqzwInqWbnJknyHRTlC72fNW+C+ySAe5RE8HeO9THw=')),
+              modeInfo: CosmosModeInfo.single(CosmosSignMode.signModeDirect),
+              sequence: 34,
+            ),
+          ],
+          fee: CosmosFee(
+            gasLimit: BigInt.parse('20000'),
+            amount: <CosmosCoin>[CosmosCoin(denom: 'ukex', amount: BigInt.parse('100'))],
+          ),
+        ),
+        txBody: CosmosTxBody(
+          messages: <ProtobufAny>[
+            TestMsgSend(
+              fromAddress: 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+              toAddress: 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+              amount: <CosmosCoin>[
+                CosmosCoin(denom: 'ukex', amount: BigInt.from(12)),
+              ],
+            ),
+          ],
+          memo: '123123',
+        ),
+      );
+
+      // Act
+      Uint8List actualProtoBytes = actualCosmosSignDoc.toProtoBytes();
+
+      // Assert
+      Uint8List expectedProtoBytes = base64Decode(
+        'CpEBCoYBChwvY29zbW9zLmJhbmsudjFiZXRhMS5Nc2dTZW5kEmYKK2tpcmExNDNxOHZ4cHZ1eWt0OXBxNTBlNmhuZzlzMzh2bXk4NDRuOGs5d3gSK2tpcmExNDNxOHZ4cHZ1eWt0OXBxNTBlNmhuZzlzMzh2bXk4NDRuOGs5d3gaCgoEdWtleBICMTISBjEyMzEyMxJnClIKSAofL2Nvc21vcy5jcnlwdG8uc2VjcDI1NmsxLlB1YktleRIlCiMKIQJS2rPAiepZucmSfIdFOULvZ81b4L7JIB7lETwd471MfBIECgIIARgiEhEKCwoEdWtleBIDMTAwEKCcARoJdGVzdG5ldC0xIAQ=',
+      );
+      expect(actualProtoBytes, expectedProtoBytes);
+    });
+  });
+
+  group('Tests of CosmosSignDoc.getDirectSignBytes()', () {
+    test('Should [return protobuf bytes] representing CosmosSignDoc', () {
+      // Arrange
+      CosmosSignDoc actualCosmosSignDoc = CosmosSignDoc(
+        txBody: CosmosTxBody(
+          messages: <ProtobufAny>[
+            TestMsgSend(
+              fromAddress: 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+              toAddress: 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+              amount: <CosmosCoin>[
+                CosmosCoin(denom: 'ukex', amount: BigInt.from(12)),
+              ],
+            ),
+          ],
+          memo: '123123',
+        ),
+        authInfo: CosmosAuthInfo(
+          signerInfos: <CosmosSignerInfo>[
+            CosmosSignerInfo(
+              publicKey: CosmosSimplePublicKey(base64Decode('CiECUtqzwInqWbnJknyHRTlC72fNW+C+ySAe5RE8HeO9THw=')),
+              modeInfo: CosmosModeInfo.single(CosmosSignMode.signModeDirect),
+              sequence: 34,
+            ),
+          ],
+          fee: CosmosFee(
+            gasLimit: BigInt.parse('20000'),
+            amount: <CosmosCoin>[CosmosCoin(denom: 'ukex', amount: BigInt.parse('100'))],
+          ),
+        ),
+        chainId: 'testnet-1',
+        accountNumber: 4,
+      );
+
+      // Act
+      Uint8List actualDirectSignBytes = actualCosmosSignDoc.getDirectSignBytes();
+
+      // Assert
+      Uint8List expectedDirectSignBytes = base64Decode(
+        'CpEBCoYBChwvY29zbW9zLmJhbmsudjFiZXRhMS5Nc2dTZW5kEmYKK2tpcmExNDNxOHZ4cHZ1eWt0OXBxNTBlNmhuZzlzMzh2bXk4NDRuOGs5d3gSK2tpcmExNDNxOHZ4cHZ1eWt0OXBxNTBlNmhuZzlzMzh2bXk4NDRuOGs5d3gaCgoEdWtleBICMTISBjEyMzEyMxJnClIKSAofL2Nvc21vcy5jcnlwdG8uc2VjcDI1NmsxLlB1YktleRIlCiMKIQJS2rPAiepZucmSfIdFOULvZ81b4L7JIB7lETwd471MfBIECgIIARgiEhEKCwoEdWtleBIDMTAwEKCcARoJdGVzdG5ldC0xIAQ=',
+      );
+      expect(actualDirectSignBytes, expectedDirectSignBytes);
+    });
+  });
+}

--- a/test/transactions/cosmos/cosmos_signer_info_test.dart
+++ b/test/transactions/cosmos/cosmos_signer_info_test.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of CosmosSignerInfo.toProtoBytes()', () {
+    test('Should [return protobuf bytes] representing CosmosSignerInfo', () {
+      // Arrange
+      CosmosSignerInfo actualCosmosSignerInfo = CosmosSignerInfo(
+        publicKey: CosmosSimplePublicKey(base64Decode('CiECUtqzwInqWbnJknyHRTlC72fNW+C+ySAe5RE8HeO9THw=')),
+        modeInfo: CosmosModeInfo.single(CosmosSignMode.signModeDirect),
+        sequence: 34,
+      );
+
+      // Act
+      Uint8List actualProtoBytes = actualCosmosSignerInfo.toProtoBytes();
+
+      // Assert
+      Uint8List expectedProtoBytes = base64Decode(
+        'CkgKHy9jb3Ntb3MuY3J5cHRvLnNlY3AyNTZrMS5QdWJLZXkSJQojCiECUtqzwInqWbnJknyHRTlC72fNW+C+ySAe5RE8HeO9THwSBAoCCAEYIg==',
+      );
+
+      expect(actualProtoBytes, expectedProtoBytes);
+    });
+  });
+
+  group('Tests of CosmosSignerInfo.toProtoJson()', () {
+    test('Should [return JSON] representing CosmosSignerInfo', () {
+      // Arrange
+      CosmosSignerInfo actualCosmosSignerInfo = CosmosSignerInfo(
+        publicKey: CosmosSimplePublicKey(base64Decode('CiECUtqzwInqWbnJknyHRTlC72fNW+C+ySAe5RE8HeO9THw=')),
+        modeInfo: CosmosModeInfo.single(CosmosSignMode.signModeDirect),
+        sequence: 34,
+      );
+
+      // Act
+      Map<String, dynamic> actualData = actualCosmosSignerInfo.toProtoJson();
+
+      // Assert
+      Map<String, dynamic> expectedData = <String, dynamic>{
+        'public_key': <String, String>{
+          '@type': '/cosmos.crypto.secp256k1.PubKey',
+          'key': 'CiECUtqzwInqWbnJknyHRTlC72fNW+C+ySAe5RE8HeO9THw=',
+        },
+        'mode_info': <String, Map<String, String>>{
+          'single': <String, String>{'mode': 'SIGN_MODE_DIRECT'}
+        },
+        'sequence': '34'
+      };
+
+      expect(actualData, expectedData);
+    });
+  });
+}

--- a/test/transactions/cosmos/cosmos_tx_body_test.dart
+++ b/test/transactions/cosmos/cosmos_tx_body_test.dart
@@ -1,0 +1,79 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+import 'test_data/test_msg_send.dart';
+
+void main() {
+  group('Tests of CosmosTxBody.toProtoBytes()', () {
+    test('Should [return protobuf bytes] representing CosmosTxBody', () {
+      // Arrange
+      CosmosTxBody actualCosmosTxBody = CosmosTxBody(
+        messages: <ProtobufAny>[
+          TestMsgSend(
+            fromAddress: 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+            toAddress: 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+            amount: <CosmosCoin>[
+              CosmosCoin(denom: 'ukex', amount: BigInt.from(12)),
+            ],
+          ),
+        ],
+        memo: '123123',
+      );
+
+      // Act
+      Uint8List actualProtoBytes = actualCosmosTxBody.toProtoBytes();
+
+      // Assert
+      Uint8List expectedProtoBytes = base64Decode(
+        'CoYBChwvY29zbW9zLmJhbmsudjFiZXRhMS5Nc2dTZW5kEmYKK2tpcmExNDNxOHZ4cHZ1eWt0OXBxNTBlNmhuZzlzMzh2bXk4NDRuOGs5d3gSK2tpcmExNDNxOHZ4cHZ1eWt0OXBxNTBlNmhuZzlzMzh2bXk4NDRuOGs5d3gaCgoEdWtleBICMTISBjEyMzEyMw==',
+      );
+
+      expect(actualProtoBytes, expectedProtoBytes);
+    });
+  });
+
+  group('Tests of CosmosTxBody.toProtoJson()', () {
+    test('Should [return JSON] representing CosmosTxBody', () {
+      // Arrange
+      CosmosTxBody actualCosmosTxBody = CosmosTxBody(
+        messages: <ProtobufAny>[
+          TestMsgSend(
+            fromAddress: 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+            toAddress: 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+            amount: <CosmosCoin>[
+              CosmosCoin(denom: 'ukex', amount: BigInt.from(12)),
+            ],
+          ),
+        ],
+        memo: '123123',
+      );
+
+      // Act
+      Map<String, dynamic> actualData = actualCosmosTxBody.toProtoJson();
+
+      // Assert
+      Map<String, dynamic> expectedData = <String, dynamic>{
+        'messages': <Map<String, Object>>[
+          <String, Object>{
+            '@type': '/cosmos.bank.v1beta1.MsgSend',
+            'from_address': 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+            'to_address': 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+            'amount': <Map<String, String>>[
+              <String, String>{'denom': 'ukex', 'amount': '12'}
+            ]
+          }
+        ],
+        'memo': '123123',
+        'timeout_height': '0',
+        'extension_options': <dynamic>[],
+        'non_critical_extension_options': <dynamic>[]
+      };
+
+      expect(actualData, expectedData);
+    });
+  });
+}

--- a/test/transactions/cosmos/cosmos_tx_test.dart
+++ b/test/transactions/cosmos/cosmos_tx_test.dart
@@ -1,0 +1,190 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+import 'test_data/test_msg_send.dart';
+
+void main() {
+  group('Tests of CosmosTx.toProtoBytes()', () {
+    test('Should [return protobuf bytes] representing CosmosTx', () {
+      // Arrange
+      CosmosTx actualCosmosTx = CosmosTx.signed(
+        body: CosmosTxBody(
+          messages: <ProtobufAny>[
+            TestMsgSend(
+              fromAddress: 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+              toAddress: 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+              amount: <CosmosCoin>[
+                CosmosCoin(denom: 'ukex', amount: BigInt.from(12)),
+              ],
+            ),
+          ],
+          memo: '123123',
+        ),
+        authInfo: CosmosAuthInfo(
+          signerInfos: <CosmosSignerInfo>[
+            CosmosSignerInfo(
+              publicKey: CosmosSimplePublicKey(base64Decode('CiECUtqzwInqWbnJknyHRTlC72fNW+C+ySAe5RE8HeO9THw=')),
+              modeInfo: CosmosModeInfo.single(CosmosSignMode.signModeDirect),
+              sequence: 34,
+            ),
+          ],
+          fee: CosmosFee(
+            gasLimit: BigInt.parse('20000'),
+            amount: <CosmosCoin>[CosmosCoin(denom: 'ukex', amount: BigInt.parse('100'))],
+          ),
+        ),
+        signatures: <CosmosSignature>[
+          CosmosSignature(
+            s: BigInt.parse('25762741804310061202983426251141315765040090201449012852222856059029735330091'),
+            r: BigInt.parse('38405229888052653976493395571873434429328497679884784055390575135932131163697'),
+          ),
+        ],
+      );
+
+      // Act
+      Uint8List actualProtoBytes = actualCosmosTx.toProtoBytes();
+
+      // Assert
+      Uint8List expectedProtoBytes = base64Decode(
+        'CpEBCoYBChwvY29zbW9zLmJhbmsudjFiZXRhMS5Nc2dTZW5kEmYKK2tpcmExNDNxOHZ4cHZ1eWt0OXBxNTBlNmhuZzlzMzh2bXk4NDRuOGs5d3gSK2tpcmExNDNxOHZ4cHZ1eWt0OXBxNTBlNmhuZzlzMzh2bXk4NDRuOGs5d3gaCgoEdWtleBICMTISBjEyMzEyMxJnClIKSAofL2Nvc21vcy5jcnlwdG8uc2VjcDI1NmsxLlB1YktleRIlCiMKIQJS2rPAiepZucmSfIdFOULvZ81b4L7JIB7lETwd471MfBIECgIIARgiEhEKCwoEdWtleBIDMTAwEKCcARpAVOiW/TF7pRINaMatMux1KZP3GRiXkAbvXdoQEQr1vjE49THzl1gerUme+MsMjIBoWw9LUiMc6T/NfnLhr1vRKw==',
+      );
+
+      expect(actualProtoBytes, expectedProtoBytes);
+    });
+  });
+
+  group('Tests of CosmosTx.toProtoJson()', () {
+    test('Should [return JSON] representing CosmosTx', () {
+      // Arrange
+      CosmosTx actualCosmosTx = CosmosTx.signed(
+        body: CosmosTxBody(
+          messages: <ProtobufAny>[
+            TestMsgSend(
+              fromAddress: 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+              toAddress: 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+              amount: <CosmosCoin>[
+                CosmosCoin(denom: 'ukex', amount: BigInt.from(12)),
+              ],
+            ),
+          ],
+          memo: '123123',
+        ),
+        authInfo: CosmosAuthInfo(
+          signerInfos: <CosmosSignerInfo>[
+            CosmosSignerInfo(
+              publicKey: CosmosSimplePublicKey(base64Decode('CiECUtqzwInqWbnJknyHRTlC72fNW+C+ySAe5RE8HeO9THw=')),
+              modeInfo: CosmosModeInfo.single(CosmosSignMode.signModeDirect),
+              sequence: 34,
+            ),
+          ],
+          fee: CosmosFee(
+            gasLimit: BigInt.parse('20000'),
+            amount: <CosmosCoin>[CosmosCoin(denom: 'ukex', amount: BigInt.parse('100'))],
+          ),
+        ),
+        signatures: <CosmosSignature>[
+          CosmosSignature(
+            s: BigInt.parse('25762741804310061202983426251141315765040090201449012852222856059029735330091'),
+            r: BigInt.parse('38405229888052653976493395571873434429328497679884784055390575135932131163697'),
+          ),
+        ],
+      );
+
+      // Act
+      Map<String, dynamic> actualData = actualCosmosTx.toProtoJson();
+
+      // Assert
+      Map<String, dynamic> expectedData = <String, dynamic>{
+        'body': <String, Object>{
+          'messages': <Map<String, Object>>[
+            <String, Object>{
+              '@type': '/cosmos.bank.v1beta1.MsgSend',
+              'from_address': 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+              'to_address': 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+              'amount': <Map<String, String>>[
+                <String, String>{'denom': 'ukex', 'amount': '12'}
+              ]
+            }
+          ],
+          'memo': '123123',
+          'timeout_height': '0',
+          'extension_options': <dynamic>[],
+          'non_critical_extension_options': <dynamic>[]
+        },
+        'auth_info': <String, Object>{
+          'signer_infos': <Map<String, Object>>[
+            <String, Object>{
+              'public_key': <String, String>{'@type': '/cosmos.crypto.secp256k1.PubKey', 'key': 'CiECUtqzwInqWbnJknyHRTlC72fNW+C+ySAe5RE8HeO9THw='},
+              'mode_info': <String, Map<String, String>>{
+                'single': <String, String>{'mode': 'SIGN_MODE_DIRECT'}
+              },
+              'sequence': '34'
+            }
+          ],
+          'fee': <String, Object?>{
+            'gas_limit': '20000',
+            'amount': <Map<String, String>>[
+              <String, String>{'denom': 'ukex', 'amount': '100'}
+            ],
+            'payer': null,
+            'granter': null
+          }
+        },
+        'signatures': <String>['VOiW/TF7pRINaMatMux1KZP3GRiXkAbvXdoQEQr1vjE49THzl1gerUme+MsMjIBoWw9LUiMc6T/NfnLhr1vRKw==']
+      };
+
+      expect(actualData, expectedData);
+    });
+  });
+
+  group('Tests of CosmosTx.getTransactionHash()', () {
+    test('Should [return hash] representing transaction ID', () {
+      // Arrange
+      CosmosTx actualCosmosTx = CosmosTx.signed(
+        body: CosmosTxBody(
+          messages: <ProtobufAny>[
+            TestMsgSend(
+              fromAddress: 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+              toAddress: 'kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx',
+              amount: <CosmosCoin>[
+                CosmosCoin(denom: 'ukex', amount: BigInt.from(12)),
+              ],
+            ),
+          ],
+          memo: '123123',
+        ),
+        authInfo: CosmosAuthInfo(
+          signerInfos: <CosmosSignerInfo>[
+            CosmosSignerInfo(
+              publicKey: CosmosSimplePublicKey(base64Decode('CiECUtqzwInqWbnJknyHRTlC72fNW+C+ySAe5RE8HeO9THw=')),
+              modeInfo: CosmosModeInfo.single(CosmosSignMode.signModeDirect),
+              sequence: 34,
+            ),
+          ],
+          fee: CosmosFee(
+            gasLimit: BigInt.parse('20000'),
+            amount: <CosmosCoin>[CosmosCoin(denom: 'ukex', amount: BigInt.parse('100'))],
+          ),
+        ),
+        signatures: <CosmosSignature>[
+          CosmosSignature(
+            s: BigInt.parse('25762741804310061202983426251141315765040090201449012852222856059029735330091'),
+            r: BigInt.parse('38405229888052653976493395571873434429328497679884784055390575135932131163697'),
+          ),
+        ],
+      );
+
+      // Act
+      String actualTransactionHash = actualCosmosTx.getTransactionHash();
+
+      // Assert
+      String expectedTransactionHash = '0xd7120d2b6059168953c9bad21db6ee3f346ed5787fdec57a8e9b13992359fd8a';
+
+      expect(actualTransactionHash, expectedTransactionHash);
+    });
+  });
+}

--- a/test/transactions/cosmos/mode_info/cosmos_mode_info_multi_test.dart
+++ b/test/transactions/cosmos/mode_info/cosmos_mode_info_multi_test.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of CosmosModeInfoMulti.toProtoBytes()', () {
+    test('Should [return protobuf bytes] representing CosmosModeInfoMulti', () {
+      // Arrange
+      CosmosModeInfoMulti actualCosmosModeInfoMulti = CosmosModeInfoMulti(
+        bitArray: CosmosCompactBitArray(
+          extraBitsStored: 1,
+          elems: base64Decode('AQ=='),
+        ),
+        modeInfos: <CosmosModeInfo>[
+          CosmosModeInfo.single(CosmosSignMode.signModeDirect),
+          CosmosModeInfo.single(CosmosSignMode.signModeDirect),
+        ],
+      );
+
+      // Act
+      Uint8List actualProtoBytes = actualCosmosModeInfoMulti.toProtoBytes();
+
+      // Assert
+      Uint8List expectedProtoBytes = Uint8List.fromList(<int>[10, 5, 8, 1, 18, 1, 1, 18, 4, 10, 2, 8, 1, 18, 4, 10, 2, 8, 1]);
+
+      expect(actualProtoBytes, expectedProtoBytes);
+    });
+  });
+
+  group('Tests of CosmosModeInfoMulti.toProtoJson()', () {
+    test('Should [return JSON] representing CosmosModeInfoMulti', () {
+      // Arrange
+      CosmosModeInfoMulti actualCosmosModeInfoMulti = CosmosModeInfoMulti(
+        bitArray: CosmosCompactBitArray(
+          extraBitsStored: 1,
+          elems: base64Decode('AQ=='),
+        ),
+        modeInfos: <CosmosModeInfo>[
+          CosmosModeInfo.single(CosmosSignMode.signModeDirect),
+          CosmosModeInfo.single(CosmosSignMode.signModeDirect),
+        ],
+      );
+
+      // Act
+      Map<String, dynamic> actualData = actualCosmosModeInfoMulti.toProtoJson();
+
+      // Assert
+      Map<String, dynamic> expectedData = <String, dynamic>{
+        'bitarray': <String, Object>{'extra_bits_stored': 1, 'elems': 'AQ=='},
+        'mode_infos': <Map<String, Map<String, String>>>[
+          <String, Map<String, String>>{
+            'single': <String, String>{'mode': 'SIGN_MODE_DIRECT'}
+          },
+          <String, Map<String, String>>{
+            'single': <String, String>{'mode': 'SIGN_MODE_DIRECT'}
+          }
+        ]
+      };
+
+      expect(actualData, expectedData);
+    });
+  });
+}

--- a/test/transactions/cosmos/mode_info/cosmos_mode_info_single_test.dart
+++ b/test/transactions/cosmos/mode_info/cosmos_mode_info_single_test.dart
@@ -1,0 +1,36 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of CosmosModeInfoSingle.toProtoBytes()', () {
+    test('Should [return protobuf bytes] representing CosmosModeInfoSingle', () {
+      // Arrange
+      CosmosModeInfoSingle actualCosmosModeInfoSingle = CosmosModeInfoSingle(CosmosSignMode.signModeDirect);
+
+      // Act
+      Uint8List actualProtoBytes = actualCosmosModeInfoSingle.toProtoBytes();
+
+      // Assert
+      Uint8List expectedProtoBytes = Uint8List.fromList(<int>[8, 1]);
+
+      expect(actualProtoBytes, expectedProtoBytes);
+    });
+  });
+
+  group('Tests of CosmosModeInfoSingle.toProtoJson()', () {
+    test('Should [return JSON] representing CosmosModeInfoSingle', () {
+      // Arrange
+      CosmosModeInfoSingle actualCosmosModeInfoSingle = CosmosModeInfoSingle(CosmosSignMode.signModeDirect);
+
+      // Act
+      Map<String, dynamic> actualData = actualCosmosModeInfoSingle.toProtoJson();
+
+      // Assert
+      Map<String, dynamic> expectedData = <String, dynamic>{'mode': 'SIGN_MODE_DIRECT'};
+
+      expect(actualData, expectedData);
+    });
+  });
+}

--- a/test/transactions/cosmos/mode_info/cosmos_mode_info_test.dart
+++ b/test/transactions/cosmos/mode_info/cosmos_mode_info_test.dart
@@ -1,0 +1,96 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  group('Tests of CosmosModeInfo.toProtoBytes()', () {
+    test('Should [return protobuf bytes] representing CosmosModeInfo with CosmosModeInfoMulti', () {
+      // Arrange
+      CosmosModeInfo actualCosmosModeInfo = CosmosModeInfo.multi(
+        bitArray: CosmosCompactBitArray(
+          extraBitsStored: 1,
+          elems: base64Decode('AQ=='),
+        ),
+        modeInfos: <CosmosModeInfo>[
+          CosmosModeInfo.single(CosmosSignMode.signModeDirect),
+          CosmosModeInfo.single(CosmosSignMode.signModeDirect),
+        ],
+      );
+
+      // Act
+      Uint8List actualProtoBytes = actualCosmosModeInfo.toProtoBytes();
+
+      // Assert
+      Uint8List expectedProtoBytes = Uint8List.fromList(<int>[18, 19, 10, 5, 8, 1, 18, 1, 1, 18, 4, 10, 2, 8, 1, 18, 4, 10, 2, 8, 1]);
+
+      expect(actualProtoBytes, expectedProtoBytes);
+    });
+
+    test('Should [return protobuf bytes] representing CosmosModeInfo with CosmosModeInfoSingle', () {
+      // Arrange
+      CosmosModeInfo actualCosmosModeInfo = CosmosModeInfo.single(CosmosSignMode.signModeDirect);
+
+      // Act
+      Uint8List actualProtoBytes = actualCosmosModeInfo.toProtoBytes();
+
+      // Assert
+      Uint8List expectedProtoBytes = Uint8List.fromList(<int>[10, 2, 8, 1]);
+
+      expect(actualProtoBytes, expectedProtoBytes);
+    });
+  });
+
+  group('Tests of CosmosModeInfo.toProtoJson()', () {
+    test('Should [return JSON] representing CosmosModeInfo with CosmosModeInfoMulti', () {
+      // Arrange
+      CosmosModeInfo actualCosmosModeInfo = CosmosModeInfo.multi(
+        bitArray: CosmosCompactBitArray(
+          extraBitsStored: 1,
+          elems: base64Decode('AQ=='),
+        ),
+        modeInfos: <CosmosModeInfo>[
+          CosmosModeInfo.single(CosmosSignMode.signModeDirect),
+          CosmosModeInfo.single(CosmosSignMode.signModeDirect),
+        ],
+      );
+
+      // Act
+      Map<String, dynamic> actualData = actualCosmosModeInfo.toProtoJson();
+
+      // Assert
+      Map<String, dynamic> expectedData = <String, dynamic>{
+        'multi': <String, Object>{
+          'bitarray': <String, Object>{'extra_bits_stored': 1, 'elems': 'AQ=='},
+          'mode_infos': <Map<String, Map<String, String>>>[
+            <String, Map<String, String>>{
+              'single': <String, String>{'mode': 'SIGN_MODE_DIRECT'}
+            },
+            <String, Map<String, String>>{
+              'single': <String, String>{'mode': 'SIGN_MODE_DIRECT'}
+            }
+          ]
+        }
+      };
+
+      expect(actualData, expectedData);
+    });
+
+    test('Should [return JSON] representing CosmosModeInfo with CosmosModeInfoSingle', () {
+      // Arrange
+      CosmosModeInfo actualCosmosModeInfo = CosmosModeInfo.single(CosmosSignMode.signModeDirect);
+
+      // Act
+      Map<String, dynamic> actualData = actualCosmosModeInfo.toProtoJson();
+
+      // Assert
+      Map<String, dynamic> expectedData = <String, dynamic>{
+        'single': <String, String>{'mode': 'SIGN_MODE_DIRECT'}
+      };
+
+      expect(actualData, expectedData);
+    });
+  });
+}

--- a/test/transactions/cosmos/public_key/cosmos_legacy_amino_multisig_public_key_test.dart
+++ b/test/transactions/cosmos/public_key/cosmos_legacy_amino_multisig_public_key_test.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/src/transactions/cosmos/public_key/cosmos_legacy_amino_multisig_public_key.dart';
+import 'package:cryptography_utils/src/transactions/cosmos/public_key/cosmos_simple_public_key.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Test of CosmosLegacyAminoMultisigPublicKey.toProtoBytes()', () {
+    test('Should [return protobuf bytes] representing CosmosLegacyAminoMultisigPublicKey', () {
+      // Arrange
+      CosmosLegacyAminoMultisigPublicKey actualCosmosLegacyAminoMultisigPublicKey = CosmosLegacyAminoMultisigPublicKey(
+        threshold: 1,
+        publicKeys: <CosmosSimplePublicKey>[
+          CosmosSimplePublicKey(base64Decode('AurroA7jvfPd1AadmmOvWM2rJSwipXfRf8yD6pLbA2DJ')),
+        ],
+      );
+
+      // Act
+      Uint8List actualProtoBytes = actualCosmosLegacyAminoMultisigPublicKey.toProtoBytes();
+
+      // Assert
+      Uint8List expectedProtoBytes = base64Decode('CAESRgofL2Nvc21vcy5jcnlwdG8uc2VjcDI1NmsxLlB1YktleRIjCiEC6uugDuO9893UBp2aY69YzaslLCKld9F/zIPqktsDYMk=');
+
+      expect(actualProtoBytes, expectedProtoBytes);
+    });
+  });
+
+  group('Tests of CosmosLegacyAminoMultisigPublicKey.toProtoJson()', () {
+    test('Should [return JSON] representing CosmosLegacyAminoMultisigPublicKey', () {
+      // Arrange
+      CosmosLegacyAminoMultisigPublicKey actualCosmosLegacyAminoMultisigPublicKey = CosmosLegacyAminoMultisigPublicKey(
+        threshold: 1,
+        publicKeys: <CosmosSimplePublicKey>[
+          CosmosSimplePublicKey(base64Decode('AurroA7jvfPd1AadmmOvWM2rJSwipXfRf8yD6pLbA2DJ')),
+        ],
+      );
+
+      // Act
+      Map<String, dynamic> actualData = actualCosmosLegacyAminoMultisigPublicKey.toProtoJson();
+
+      // Assert
+      Map<String, dynamic> expectedData = <String, dynamic>{
+        '@type': '/cosmos.crypto.multisig.LegacyAminoPubKey',
+        'threshold': 1,
+        'public_keys': <Map<String, String>>[
+          <String, String>{
+            '@type': '/cosmos.crypto.secp256k1.PubKey',
+            'key': 'AurroA7jvfPd1AadmmOvWM2rJSwipXfRf8yD6pLbA2DJ',
+          }
+        ]
+      };
+
+      expect(actualData, expectedData);
+    });
+  });
+}

--- a/test/transactions/cosmos/public_key/cosmos_simple_public_key_test.dart
+++ b/test/transactions/cosmos/public_key/cosmos_simple_public_key_test.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/src/transactions/cosmos/public_key/cosmos_simple_public_key.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of CosmosSimplePublicKey.toProtoBytes()', () {
+    test('Should [return protobuf bytes] representing CosmosSimplePublicKey', () {
+      // Arrange
+      CosmosSimplePublicKey actualCosmosSimplePublicKey = CosmosSimplePublicKey(base64Decode('AurroA7jvfPd1AadmmOvWM2rJSwipXfRf8yD6pLbA2DJ'));
+
+      // Act
+      Uint8List actualProtoBytes = actualCosmosSimplePublicKey.toProtoBytes();
+
+      // Assert
+      Uint8List expectedProtoBytes = base64Decode('CiEC6uugDuO9893UBp2aY69YzaslLCKld9F/zIPqktsDYMk=');
+
+      expect(actualProtoBytes, expectedProtoBytes);
+    });
+  });
+
+  group('Tests of CosmosSimplePublicKey.toProtoJson()', () {
+    test('Should [return JSON] representing CosmosSimplePublicKey', () {
+      // Arrange
+      CosmosSimplePublicKey actualCosmosSimplePublicKey = CosmosSimplePublicKey(base64Decode('AurroA7jvfPd1AadmmOvWM2rJSwipXfRf8yD6pLbA2DJ'));
+
+      // Act
+      Map<String, dynamic> actualData = actualCosmosSimplePublicKey.toProtoJson();
+
+      // Assert
+      Map<String, dynamic> expectedData = <String, dynamic>{
+        '@type': '/cosmos.crypto.secp256k1.PubKey',
+        'key': 'AurroA7jvfPd1AadmmOvWM2rJSwipXfRf8yD6pLbA2DJ',
+      };
+
+      expect(actualData, expectedData);
+    });
+  });
+}

--- a/test/transactions/cosmos/public_key/cosmos_val_cons_public_key_test.dart
+++ b/test/transactions/cosmos/public_key/cosmos_val_cons_public_key_test.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/src/transactions/cosmos/public_key/cosmos_val_cons_public_key.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of CosmosValConsPublicKey.toProtoBytes()', () {
+    test('Should [return protobuf bytes] representing CosmosValConsPublicKey', () {
+      // Arrange
+      CosmosValConsPublicKey actualCosmosValConsPublicKey = CosmosValConsPublicKey(base64Decode('HlixoxNZBPq4pBOYEimtSq9Ak4peBISVsIbI5ZHrEAU='));
+
+      // Act
+      Uint8List actualProtoBytes = actualCosmosValConsPublicKey.toProtoBytes();
+
+      // Assert
+      Uint8List expectedProtoBytes = base64Decode('CiAeWLGjE1kE+rikE5gSKa1Kr0CTil4EhJWwhsjlkesQBQ==');
+
+      expect(actualProtoBytes, expectedProtoBytes);
+    });
+  });
+
+  group('Tests of CosmosValConsPublicKey.toProtoJson()', () {
+    test('Should [return JSON] representing CosmosValConsPublicKey', () {
+      // Arrange
+      CosmosValConsPublicKey actualCosmosValConsPublicKey = CosmosValConsPublicKey(base64Decode('HlixoxNZBPq4pBOYEimtSq9Ak4peBISVsIbI5ZHrEAU='));
+
+      // Act
+      Map<String, dynamic> actualData = actualCosmosValConsPublicKey.toProtoJson();
+
+      // Assert
+      Map<String, dynamic> expectedData = <String, dynamic>{
+        '@type': '/cosmos.crypto.ed25519.PubKey',
+        'key': 'HlixoxNZBPq4pBOYEimtSq9Ak4peBISVsIbI5ZHrEAU=',
+      };
+
+      expect(actualData, expectedData);
+    });
+  });
+}

--- a/test/transactions/cosmos/test_data/test_msg_send.dart
+++ b/test/transactions/cosmos/test_data/test_msg_send.dart
@@ -1,0 +1,46 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+class TestMsgSend extends ProtobufAny {
+  final String fromAddress;
+  final String toAddress;
+  final List<CosmosCoin> amount;
+
+  TestMsgSend({
+    required this.fromAddress,
+    required this.toAddress,
+    required this.amount,
+  }) : super(typeUrl: '/cosmos.bank.v1beta1.MsgSend');
+
+  factory TestMsgSend.fromData(Map<String, dynamic> data) {
+    return TestMsgSend(
+      fromAddress: data['from_address'] as String,
+      toAddress: data['to_address'] as String,
+      amount: (data['amount'] as List<dynamic>).map((dynamic e) => CosmosCoin.fromProtoJson(e as Map<String, dynamic>)).toList(),
+    );
+  }
+
+  @override
+  Uint8List toProtoBytes() {
+    return ProtobufEncoder.encode(<int, AProtobufField>{
+      1: ProtobufString(fromAddress),
+      2: ProtobufString(toAddress),
+      3: ProtobufList(amount),
+    });
+  }
+
+  @override
+  Map<String, dynamic> toProtoJson() {
+    return <String, dynamic>{
+      '@type': typeUrl,
+      'from_address': fromAddress,
+      'to_address': toAddress,
+      'amount': amount.map((CosmosCoin cosmosCoin) => cosmosCoin.toProtoJson()).toList(),
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object>[fromAddress, toAddress, amount];
+}


### PR DESCRIPTION
This branch introduces the functionality for building and signing transactions in compliance with the Cosmos SDK. Currently, the only supported signing option is SIGN_MODE_DIRECT, as it's the only variant currently needed in the projects using "cryptography_utils" package. The other types, described in cosmos_sign_mode.dart, will be implemented as the project and its requirements evolve.

List of changes:
- created cosmos_signer.dart for creating Cosmos-compatible digital signatures using an ECDSA private key
- created cosmos_verifier.dart for verifying Cosmos-compatible digital signatures using an ECDSA public key
- created cosmos_signature.dart - a class storing digital signature used in Cosmos transactions
- created Dart representation of Cosmos protobuf objects ("transactions/cosmos") required to build Cosmos signing bytes and Cosmos transaction