### PR TITLE
Feature: Reimplement mnemonic validation

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cryptography_utils
 description: "Dart package containing utility methods for common cryptographic and blockchain-specific operations"
 publish_to: none
-version: 0.0.21
+version: 0.0.22
 
 environment:
   sdk: ">=3.2.6"

--- a/test/bip/bip39/mnemonic_test.dart
+++ b/test/bip/bip39/mnemonic_test.dart
@@ -8,7 +8,9 @@ void main() {
   group('Tests of Mnemonic() constructor', () {
     test('Should [return Mnemonic] from given mnemonic phrase', () {
       // Arrange
+      // @formatter:off
       List<String> actualMnemonicList = <String>['catalog', 'letter', 'frown', 'ramp', 'chest', 'van', 'pole', 'unfold', 'sound', 'unable', 'cool', 'endorse'];
+      // @formatter:on
 
       // Act
       Mnemonic actualMnemonic = Mnemonic(actualMnemonicList);
@@ -221,6 +223,51 @@ void main() {
         () => Mnemonic.fromMnemonicPhrase('catalog letter frown ramp chest van pole unfold sound unable cool require'),
         throwsA(const MnemonicException(MnemonicExceptionType.invalidChecksum)),
       );
+    });
+  });
+
+  group('Tests of Mnemonic.isValidMnemonic()', () {
+    test('Should [return TRUE] for a valid mnemonic', () {
+      // Arrange
+      // @formatter:off
+      List<String> mnemonicList = <String>['catalog', 'letter', 'frown', 'ramp', 'chest', 'van', 'pole', 'unfold', 'sound', 'unable', 'cool', 'endorse'];
+      // @formatter:on
+
+      // Act
+      bool actualValidBool = Mnemonic.isValidMnemonic(mnemonicList);
+
+      // Assert
+      bool expectedValidBool = true;
+
+      expect(actualValidBool, expectedValidBool);
+    });
+
+    test('Should [return FALSE] if mnemonic phrase has invalid length', () {
+      // Arrange
+      List<String> mnemonicList = <String>['catalog', 'letter', 'frown'];
+
+      // Act
+      bool actualValidBool = Mnemonic.isValidMnemonic(mnemonicList);
+
+      // Assert
+      bool expectedValidBool = false;
+
+      expect(actualValidBool, expectedValidBool);
+    });
+
+    test('Should [return FALSE] if mnemonic phrase has invalid checksum', () {
+      // Arrange
+      // @formatter:off
+      List<String> mnemonicList = <String>['attend', 'piano', 'mail', 'clap', 'argue', 'square', 'effort', 'cause', 'cook', 'onion', 'mouse', 'delay' ];
+      // @formatter:on
+
+      // Act
+      bool actualValidBool = Mnemonic.isValidMnemonic(mnemonicList);
+
+      // Assert
+      bool expectedValidBool = false;
+
+      expect(actualValidBool, expectedValidBool);
     });
   });
 


### PR DESCRIPTION
The purpose of this branch is to introduce a proper method of validating mnemonics, discarded in previous versions.

List of changes:
- updated mnemonic.dart with a new isValidMnemonic() method of validating mnemonics without creating a Mnemonic object. Previously implemented validation in Mnemonic object constructor has been updated to work with the converted static methods but otherwise remained unchanged as it might later be used for displaying more specific reasons on why a mnemonic is invalid.
- updated mnemonic_test.dart to include tests for the new isValidMnemonic() method