### PR TITLE
Feature: Import Bech32

### DIFF
--- a/lib/src/bip/bip32/address_encoders/bitcoin/bitcoin_p2wpkh_address_encoder.dart
+++ b/lib/src/bip/bip32/address_encoders/bitcoin/bitcoin_p2wpkh_address_encoder.dart
@@ -26,6 +26,6 @@ class BitcoinP2WPKHAddressEncoder extends ABlockchainAddressEncoder<Secp256k1Pub
     Uint8List publicKeyFingerprint = Sha256().convert(publicKey.compressed).byteList;
     Uint8List publicKeyHash = Ripemd160().process(publicKeyFingerprint);
 
-    return SegwitBech32Codec.encode(hrp, _witnessVersion, publicKeyHash);
+    return SegWitEncoder().encode(SegWit(hrp, _witnessVersion, publicKeyHash));
   }
 }

--- a/lib/src/bip/bip32/address_encoders/cosmos_address_encoder.dart
+++ b/lib/src/bip/bip32/address_encoders/cosmos_address_encoder.dart
@@ -22,7 +22,7 @@ class CosmosAddressEncoder extends ABlockchainAddressEncoder<Secp256k1PublicKey>
   String encodePublicKey(Secp256k1PublicKey publicKey) {
     Uint8List publicKeyFingerprint = Sha256().convert(publicKey.compressed).byteList;
     Uint8List publicKeyHash = Ripemd160().process(publicKeyFingerprint);
-
-    return Bech32Codec.encode(Bech32Pair(hrp: hrp, data: publicKeyHash));
+    Bech32 bech32 = Bech32(hrp, publicKeyHash);
+    return Bech32Encoder().encode(bech32);
   }
 }

--- a/lib/src/transactions/cosmos/cosmos_acc_address.dart
+++ b/lib/src/transactions/cosmos/cosmos_acc_address.dart
@@ -9,27 +9,29 @@ class CosmosAccAddress extends AProtobufField {
   final String hrp;
 
   /// The bytes of the address
-  final Uint8List bytes;
+  final Uint8List uint8List;
 
   /// Creates [CosmosAccountAddress] from a Bech32 encoded address.
   factory CosmosAccAddress(String address) {
-    Bech32Pair decodedBech32 = Bech32Codec.decode(address);
-    return CosmosAccAddress._(decodedBech32.hrp, decodedBech32.data);
+    Bech32 decodedBech32 = Bech32Decoder().decode(address);
+    return CosmosAccAddress._(decodedBech32.hrp, decodedBech32.uint8List);
   }
 
   /// Private constructor used by the factory to initialize the hrp and bytes.
-  const CosmosAccAddress._(this.hrp, this.bytes);
+  const CosmosAccAddress._(this.hrp, this.uint8List);
 
   @override
   List<int> encode(int fieldNumber) {
-    return ProtobufBytes(bytes).encode(fieldNumber);
+    return ProtobufBytes(uint8List).encode(fieldNumber);
   }
 
   /// Returns the Bech32 encoded address as a string.
-  String get value => Bech32Codec.encode(Bech32Pair(hrp: hrp, data: bytes));
+  String get value {
+    return Bech32Encoder().encode(Bech32(hrp, uint8List));
+  }
 
   @override
-  List<Object?> get props => <Object?>[hrp, bytes];
+  List<Object?> get props => <Object?>[hrp, uint8List];
 
   @override
   String toString() => value;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cryptography_utils
 description: "Dart package containing utility methods for common cryptographic and blockchain-specific operations"
 publish_to: none
-version: 0.0.24
+version: 0.0.25
 
 environment:
   sdk: ">=3.2.6"


### PR DESCRIPTION
The purpose of this branch is to replace Bech32 from bech32 library with our implementation in codec_utils.

List of changes:
- updated Bech32 implementation to use codec_utils in bitcoin_p2wpkh_address_encoder.dart, cosmos_address_encoder.dart, cosmos_acc_address.dart