### PR TITLE
Feature: Solana transactions

### DIFF
--- a/lib/src/signer/export.dart
+++ b/lib/src/signer/export.dart
@@ -9,3 +9,7 @@ export 'cosmos/cosmos_verifier.dart';
 export 'ethereum/ethereum_signature.dart';
 export 'ethereum/ethereum_signer.dart';
 export 'ethereum/ethereum_verifier.dart';
+
+//Solana
+export 'solana/solana_signature.dart';
+export 'solana/solana_signer.dart';

--- a/lib/src/signer/solana/solana_signature.dart
+++ b/lib/src/signer/solana/solana_signature.dart
@@ -1,0 +1,36 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// Represents a Solana digital signature, encapsulating the typical components of an EDDSA signature used in Solana transactions.
+class SolanaSignature extends ASignature {
+  /// The standard length of Solana signatures.
+  static const int solSignatureLength = 64;
+
+  /// The [r] value of the EDDSA signature, representing one half of the digital signature.
+  final Uint8List r;
+
+  /// The [s] value of the EDDSA signature, representing the other half of the digital signature.
+  final Uint8List s;
+
+  /// Constructs an instance of [SolanaSignature] with the specified [r] and [s] components.
+  const SolanaSignature({required this.r, required this.s});
+
+  /// Constructs an instance of [SolanaSignature] from a byte array.
+  factory SolanaSignature.fromBytes(Uint8List bytes) {
+    if (bytes.length != solSignatureLength) {
+      throw const FormatException('Invalid signature bytes');
+    }
+
+    Uint8List r = bytes.sublist(0, 32);
+    Uint8List s = bytes.sublist(32, 64);
+    return SolanaSignature(r: r, s: s);
+  }
+
+  /// Gets the byte representation of the 'r' and 's' components.
+  @override
+  Uint8List get bytes => Uint8List.fromList(r + s);
+
+  @override
+  List<Object?> get props => <Object?>[r, s];
+}

--- a/lib/src/signer/solana/solana_signer.dart
+++ b/lib/src/signer/solana/solana_signer.dart
@@ -1,0 +1,22 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:cryptography_utils/src/cdsa/eddsa/ed25519/signer/ed25519_signer.dart';
+import 'package:cryptography_utils/src/cdsa/eddsa/ed25519/signer/ed_signature.dart';
+
+/// Provides functionality for creating Solana-compatible digital signatures using an ED25519 private key.
+class SolanaSigner {
+  /// The ED25519 private key used for signing messages.
+  final ED25519PrivateKey _ed25519PrivateKey;
+
+  /// Constructs an [SolanaSigner] with the provided ED25519 private key.
+  SolanaSigner(this._ed25519PrivateKey);
+
+  /// Signs a digest and returns the signature as an [SolanaSignature].
+  SolanaSignature sign(Uint8List message) {
+    ED25519Signer signer = ED25519Signer(privateKey: _ed25519PrivateKey, hashFunction: Sha512());
+
+    EDSignature edSignature = signer.sign(message);
+    return SolanaSignature(r: edSignature.r, s: edSignature.s);
+  }
+}

--- a/lib/src/transactions/export.dart
+++ b/lib/src/transactions/export.dart
@@ -23,7 +23,20 @@ export 'ethereum/access_list_bytes_item.dart';
 export 'ethereum/ethereum_eip1559_transaction.dart';
 export 'ethereum/ethereum_raw_bytes_transaction.dart';
 
+// Solana
+export 'solana/a_solana_message.dart';
+export 'solana/a_solana_transaction_message.dart';
+export 'solana/instructions/a_solana_instruction_decoded.dart';
+export 'solana/instructions/solana_compiled_instruction.dart';
+export 'solana/instructions/solana_instructions.dart';
+export 'solana/solana_legacy_message.dart';
+export 'solana/solana_message_header.dart';
+export 'solana/solana_pubkey.dart';
+export 'solana/solana_raw_message.dart';
+export 'solana/solana_v0_message.dart';
+
 // Generic
+// ignore: directives_ordering
 export 'sign_data_type.dart';
 export 'token_amount.dart';
 export 'token_denomination_type.dart';

--- a/lib/src/transactions/sign_data_type.dart
+++ b/lib/src/transactions/sign_data_type.dart
@@ -1,7 +1,7 @@
 enum SignDataType {
-  /// For signing message usage, like EIP-191 personal sign data
+  /// For signing message bytes.
   rawBytes,
 
-  /// EIP-2718 typed transaction of unsigned transaction data
+  /// For signing transaction data.
   typedTransaction,
 }

--- a/lib/src/transactions/solana/a_solana_message.dart
+++ b/lib/src/transactions/solana/a_solana_message.dart
@@ -1,0 +1,25 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:equatable/equatable.dart';
+
+abstract class ASolanaMessage extends Equatable {
+  const ASolanaMessage();
+
+  /// Creates a new instance of [ASolanaMessage] from serialized data,
+  /// returning [SolanaRawMessage] or [ASolanaTransactionMessage] depending on [SignDataType].
+  factory ASolanaMessage.fromSerializedData(SignDataType signDataType, Uint8List data) {
+    switch (signDataType) {
+      case SignDataType.typedTransaction:
+        return SolanaLegacyMessage.fromSerializedData(data);
+      case SignDataType.rawBytes:
+        try {
+          return SolanaV0Message.fromSerializedData(data);
+        } catch (_) {
+          return SolanaRawMessage.fromSerializedData(data);
+        }
+    }
+  }
+
+  String? get message => null;
+}

--- a/lib/src/transactions/solana/a_solana_transaction_message.dart
+++ b/lib/src/transactions/solana/a_solana_transaction_message.dart
@@ -1,0 +1,40 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+abstract class ASolanaTransactionMessage extends ASolanaMessage {
+  final SolanaMessageHeader header;
+
+  /// List of all account addresses required by its instructions. Addresses are stored as raw bytes.
+  /// The account keys list starts with a compact-u16 number indicating how many addresses it contains.
+  /// https://solana.com/docs/core/transactions#array-of-account-addresses
+  final List<SolanaPubKey> accountKeysList;
+
+  /// Every transaction requires a recent blockhash that serves two purposes:
+  ///
+  /// 1. Acts as a timestamp for when the transaction was created
+  /// 2. Prevents duplicate transactions
+  ///
+  /// A blockhash expires after 150 blocks (about 1 minute assuming 400ms block times),
+  /// after which the transaction is considered expired and cannot be processed.
+  /// https://solana.com/docs/core/transactions#recent-blockhash
+  final Uint8List recentBlockhash;
+
+  /// An array of instructions in the CompiledInstruction type. It starts with a compact-u16 data length followed by the instruction data.
+  /// https://solana.com/docs/core/transactions#array-of-instructions
+  final List<SolanaCompiledInstruction> compiledInstructions;
+
+  const ASolanaTransactionMessage({
+    required this.header,
+    required this.accountKeysList,
+    required this.recentBlockhash,
+    required this.compiledInstructions,
+  });
+
+  List<ASolanaInstructionDecoded> get decodedInstructions {
+    List<SolanaPubKey> accountKeyBytes = accountKeysList.map((SolanaPubKey solanaPubKey) => solanaPubKey).toList(growable: false);
+    return compiledInstructions
+        .map((SolanaCompiledInstruction solanaCompiledInstruction) => ASolanaInstructionDecoded.decode(solanaCompiledInstruction, accountKeyBytes))
+        .toList(growable: false);
+  }
+}

--- a/lib/src/transactions/solana/instructions/a_solana_instruction_decoded.dart
+++ b/lib/src/transactions/solana/instructions/a_solana_instruction_decoded.dart
@@ -1,0 +1,258 @@
+import 'dart:core';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:cryptography_utils/src/transactions/solana/instructions/solana_program_type.dart';
+import 'package:cryptography_utils/src/utils/solana_utils.dart';
+import 'package:equatable/equatable.dart';
+
+/// Abstract base class representing a decoded Solana instruction.
+abstract class ASolanaInstructionDecoded extends Equatable {
+  static const int solDecimalPrecision = 9;
+  final String _programId;
+
+  /// Creates a new decoded Solana instruction with the given [programId].
+  const ASolanaInstructionDecoded({required String programId}) : _programId = programId;
+
+  /// Decodes a [SolanaCompiledInstruction] into the appropriate [ASolanaInstructionDecoded] subclass based on the program ID and data.
+  factory ASolanaInstructionDecoded.decode(SolanaCompiledInstruction solanaInstruction, List<SolanaPubKey> accountKeys) {
+    if (accountKeys.isEmpty || solanaInstruction.programIdIndex >= accountKeys.length) {
+      return const SolanaInvalidInstruction();
+    }
+
+    /// Program id identifies the program that processes the instruction. It is also the program's address on Solana blockchain.
+    /// The address is stored in account keys list, and its position on the list is indicated by [programIdIndex] in the [SolanaCompiledInstruction].
+    /// Program id is similar to Contract Address on Ethereum chain.
+    /// Examples in switch case below.
+    String programId = accountKeys[solanaInstruction.programIdIndex].toBase58();
+    SolanaProgramType? solanaProgramType = SolanaProgramType.fromProgramId(programId);
+    switch (solanaProgramType) {
+      case SolanaProgramType.system:
+        return _decodeSystemProgram(solanaInstruction, accountKeys, programId);
+      case SolanaProgramType.token:
+        return _decodeTokenProgram(solanaInstruction, accountKeys, programId);
+      case SolanaProgramType.computeBudget:
+        return _decodeComputeBudgetProgram(solanaInstruction, accountKeys, programId);
+      case SolanaProgramType.stake:
+        return _decodeStakeProgram(solanaInstruction, accountKeys, programId);
+      default:
+        return SolanaUnknownInstruction.fromSerializedData(programId);
+    }
+  }
+
+  /// Returns the amount of lamports or token in a transaction in a human-readable form.
+  TokenAmount? getAmount() {
+    if (lamports != null) {
+      return _getAmountLamports(lamports!);
+    }
+
+    if (amount != null && decimals != null) {
+      return _getAmountToken(amount!, decimals ?? 0);
+    }
+
+    return null;
+  }
+
+  /// Returns the base58-encoded address of the [mint] if it exists within an instruction.
+  String? getMintAddress() {
+    return mint;
+  }
+
+  /// Returns the base58-encoded address of the transaction sender if it exists within an instruction.
+  /// Various instructions use different field names to represent a sender.
+  /// For a single instruction, only one of these values will be non-null at the same time.
+  String? getSenderAddress() {
+    return source ?? (lamports != null ? stakeAccount : stakeAuthority ?? staker);
+  }
+
+  /// Returns the base58-encoded address of the transaction recipient if it exists within an instruction.
+  /// Various instructions use different field names to represent a recipient.
+  /// For a single instruction, only one of these values will be non-null at the same time.
+  String? getRecipientAddress() {
+    return destination ?? stakeAccount ?? newAccount;
+  }
+
+  /// Returns the base58-encoded address of the transaction signer if it exists within an instruction.
+  /// Various instructions use different field names to represent a signer.
+  /// For a single instruction, only one of these values will be non-null at the same time.
+  String? getSignerAddress() {
+    return authority ?? stakeAuthority ?? withdrawAuthority ?? staker ?? source;
+  }
+
+  /// The Base58-encoded associated account address in a [SolanaCreateIdempotentInstruction].
+  String? get account => null;
+
+  /// The amount of tokens in a [SolanaTokenTransferCheckedInstruction].
+  BigInt? get amount => null;
+
+  /// The Base58-encoded transaction authority account address in a [SolanaTokenTransferCheckedInstruction].
+  String? get authority => null;
+
+  /// The Base58-encoded account address used as a base for generating an associated account address with [seed].
+  /// Practically equal to [source] in [SolanaSystemAccountSeedInstruction] when used for creating a new Stake account.
+  String? get base => null;
+
+  /// The Base58-encoded clock sysvar program address used in a
+  /// [SolanaStakeDelegateInstruction], [SolanaStakeDeactivateInstruction], or [SolanaStakeWithdrawInstruction].
+  String? get clockSysvar => null;
+
+  /// The Base58-encoded stake custodian account address used in a [SolanaStakeInitializeInstruction].
+  String? get custodian => null;
+
+  /// The token’s decimal precision in a [SolanaTokenTransferCheckedInstruction].
+  int? get decimals => null;
+
+  /// The Base58-encoded transaction destination account address used in a [SolanaSystemTransferInstruction]
+  /// or [SolanaTokenTransferCheckedInstruction].
+  String? get destination => null;
+
+  /// The [discriminator] is the first piece of data within instruction's data array.
+  /// It is used to differentiate between instruction types belonging to the same program id.
+  int? get discriminator => null;
+
+  /// The epoch value used in a [SolanaStakeInitializeInstruction].
+  int? get epoch => null;
+
+  /// The amount of lamports (SOL) in a [SolanaSystemTransferInstruction] or a [SolanaStakeWithdrawInstruction].
+  BigInt? get lamports => null;
+
+  /// The compute unit price in micro-lamports in a [SolanaComputeBudgetUnitPriceInstruction].
+  int? get microLamports => null;
+
+  /// The Base58-encoded token mint address in a [SolanaTokenTransferCheckedInstruction].
+  String? get mint => null;
+
+  /// The Base58-encoded address of a new associated account created in a [SolanaSystemAccountSeedInstruction] for storing a stake.
+  String? get newAccount => null;
+
+  /// The Base58-encoded address of the owner program account.
+  String? get owner => null;
+
+  /// The Base58-encoded unique identifier of the Solana program that an instruction uses.
+  String? get programId => _programId;
+
+  /// The Base58-encoded rent sysvar program address used in a [SolanaStakeInitializeInstruction].
+  String? get rentSysvar => null;
+
+  /// String of ASCII chars, no longer than `Address::MAX_SEED_LEN`, used to generate [newAccount] in [SolanaSystemAccountSeedInstruction].
+  String? get seed => null;
+
+  /// The Base58-encoded transaction source account address used in a [SolanaSystemTransferInstruction],
+  /// [SolanaTokenTransferCheckedInstruction], or a [SolanaCreateIdempotentInstruction].
+  String? get source => null;
+
+  /// The number of bytes of memory to allocate in [newAccount] without funding
+  int? get space => null;
+
+  /// The Base58-encoded stake account address used in a [SolanaStakeInitializeInstruction], [SolanaStakeDelegateInstruction],
+  /// [SolanaStakeDeactivateInstruction], or [SolanaStakeWithdrawInstruction].
+  String? get stakeAccount => null;
+
+  /// The Base58-encoded stake authority account address in a [SolanaStakeDelegateInstruction] or a [SolanaStakeDeactivateInstruction],
+  /// which owns the associated [stakeAccount].
+  String? get stakeAuthority => null;
+
+  /// The Base58-encoded stake config account address used in a [SolanaStakeDelegateInstruction] or [SolanaStakeWithdrawInstruction].
+  String? get stakeConfigAccount => null;
+
+  /// The Base58-encoded stake history sysvar program address used in a [SolanaStakeDelegateInstruction] or [SolanaStakeWithdrawInstruction].
+  String? get stakeHistorySysvar => null;
+
+  /// The Base58-encoded staker account address used in a [SolanaStakeInitializeInstruction].
+  String? get staker => null;
+
+  /// The compute unit limit in a [SolanaComputeBudgetUnitLimitInstruction].
+  int? get units => null;
+
+  /// The Unix timestamp used in a [SolanaStakeInitializeInstruction].
+  int? get unixTimestamp => null;
+
+  /// The Base58-encoded vote account address used in a [SolanaStakeDelegateInstruction].
+  String? get voteAccount => null;
+
+  /// The Base58-encoded withdraw authority account address in a [SolanaStakeWithdrawInstruction],
+  /// which owns the associated [stakeAccount].
+  String? get withdrawAuthority => null;
+
+  /// The Base58-encoded account address with a stake withdraw authority in a [SolanaStakeInitializeInstruction].
+  String? get withdrawer => null;
+
+  /// Decodes a Compute Budget Program instruction.
+  static ASolanaInstructionDecoded _decodeComputeBudgetProgram(
+      SolanaCompiledInstruction solanaInstruction, List<SolanaPubKey> accountKeys, String programId) {
+    int discriminator = solanaInstruction.data[0];
+    switch (discriminator) {
+      case 2:
+        return SolanaComputeBudgetUnitLimitInstruction.fromSerializedData(solanaInstruction, programId);
+      case 3:
+        return SolanaComputeBudgetUnitPriceInstruction.fromSerializedData(solanaInstruction, programId);
+      default:
+        return SolanaUnknownInstruction.fromSerializedData(programId);
+    }
+  }
+
+  /// Decodes a Stake Program instruction.
+  static ASolanaInstructionDecoded _decodeStakeProgram(
+      SolanaCompiledInstruction solanaInstruction, List<SolanaPubKey> accountKeys, String programId) {
+    int discriminator = solanaInstruction.data[0];
+    switch (discriminator) {
+      case 0:
+        return SolanaStakeInitializeInstruction.fromSerializedData(solanaInstruction, accountKeys, programId);
+      case 2:
+        return SolanaStakeDelegateInstruction.fromSerializedData(solanaInstruction, accountKeys, programId);
+      case 4:
+        return SolanaStakeWithdrawInstruction.fromSerializedData(solanaInstruction, accountKeys, programId);
+      case 5:
+        return SolanaStakeDeactivateInstruction.fromSerializedData(solanaInstruction, accountKeys, programId);
+      default:
+        return SolanaUnknownInstruction.fromSerializedData(programId);
+    }
+  }
+
+  /// Decodes a System Program instruction.
+  static ASolanaInstructionDecoded _decodeSystemProgram(
+      SolanaCompiledInstruction solanaInstruction, List<SolanaPubKey> accountKeys, String programId) {
+    int discriminator = solanaInstruction.data[0];
+    switch (discriminator) {
+      case 2:
+        return SolanaSystemTransferInstruction.fromSerializedData(solanaInstruction, accountKeys, programId);
+      case 3:
+        return SolanaSystemAccountSeedInstruction.fromSerializedData(solanaInstruction, accountKeys, programId);
+      default:
+        return SolanaUnknownInstruction.fromSerializedData(programId);
+    }
+  }
+
+  /// Decodes a Token Program instruction.
+  static ASolanaInstructionDecoded _decodeTokenProgram(
+      SolanaCompiledInstruction solanaInstruction, List<SolanaPubKey> accountKeys, String programId) {
+    int discriminator = solanaInstruction.data[0];
+    switch (discriminator) {
+      case 12:
+        return SolanaTokenTransferCheckedInstruction.fromSerializedData(solanaInstruction, accountKeys, programId);
+      default:
+        return SolanaUnknownInstruction.fromSerializedData(programId);
+    }
+  }
+
+  /// Returns the amount of lamports in a transaction in a human-readable form.
+  TokenAmount _getAmountLamports(BigInt lamports) {
+    if (lamports == BigInt.zero) {
+      return TokenAmount.fromBigInt(denomination: SolanaUtils.solSymbol, amount: lamports);
+    }
+    return TokenAmount(
+      denomination: SolanaUtils.solSymbol,
+      amount: SolanaUtils.parseTokenAmount(lamports, solDecimalPrecision),
+    );
+  }
+
+  /// Returns the token amount in a transaction in a human-readable form.
+  TokenAmount _getAmountToken(BigInt amount, int decimals) {
+    if (amount == BigInt.zero) {
+      return TokenAmount.fromBigInt(denomination: '', amount: amount);
+    }
+    return TokenAmount(
+      denomination: '',
+      amount: SolanaUtils.parseTokenAmount(amount, decimals),
+    );
+  }
+}

--- a/lib/src/transactions/solana/instructions/compute_budget/solana_compute_budget_unit_limit_instruction.dart
+++ b/lib/src/transactions/solana/instructions/compute_budget/solana_compute_budget_unit_limit_instruction.dart
@@ -1,0 +1,55 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// An instruction which defines a specific compute unit limit that the transaction is allowed to consume.
+///
+/// Example instruction: https://solscan.io/tx/4uyy2M3xF7swQH6ZFbhxfSFLRARqGQMUi65ikzCzcaGWmKR81vubvPcrEQ4yPhaj7MYw3hBow7w9jnFREMDXyfTs?cluster=devnet
+/// {
+///     discriminator: {
+///         type: "u8",
+///         data: 2
+///     }
+///     units: {
+///         type: "u32",
+///         data: 495
+///     }
+/// }
+class SolanaComputeBudgetUnitLimitInstruction extends ASolanaInstructionDecoded {
+  /// Field order on Solscan is based on unknown rules.
+  ///
+  /// Our field order below is NOT influenced by Solscan and follows the order of data received from [SolanaCompiledInstruction]:
+  /// - instruction data array values, in order of appearance in [SolanaCompiledInstruction] data field
+  final int _discriminator;
+  final int _units;
+
+  const SolanaComputeBudgetUnitLimitInstruction({
+    required String programId,
+    required int discriminator,
+    required int units,
+  })  : _discriminator = discriminator,
+        _units = units,
+        super(programId: programId);
+
+  /// Creates a new instance of [SolanaComputeBudgetUnitLimitInstruction] from the serialized data.
+  factory SolanaComputeBudgetUnitLimitInstruction.fromSerializedData(SolanaCompiledInstruction solanaCompiledInstruction, String programId) {
+    ByteData byteData = solanaCompiledInstruction.data.buffer.asByteData();
+    int discriminator = byteData.getUint8(0);
+    int units = byteData.getUint32(1, Endian.little);
+
+    return SolanaComputeBudgetUnitLimitInstruction(
+      programId: programId,
+      discriminator: discriminator,
+      units: units,
+    );
+  }
+
+  @override
+  int? get discriminator => _discriminator;
+
+  @override
+  int? get units => _units;
+
+  @override
+  List<Object?> get props => <Object?>[programId, _discriminator, _units];
+}

--- a/lib/src/transactions/solana/instructions/compute_budget/solana_compute_budget_unit_price_instruction.dart
+++ b/lib/src/transactions/solana/instructions/compute_budget/solana_compute_budget_unit_price_instruction.dart
@@ -1,0 +1,55 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// An instruction which defines a specific unit price in “micro-lamports” to pay a higher transaction fee for higher transaction prioritization.
+///
+/// Example instruction: https://solscan.io/tx/4uyy2M3xF7swQH6ZFbhxfSFLRARqGQMUi65ikzCzcaGWmKR81vubvPcrEQ4yPhaj7MYw3hBow7w9jnFREMDXyfTs?cluster=devnet
+/// {
+///     discriminator: {
+///         type: "u8",
+///         data: 3
+///     }
+///     microLamports: {
+///         type: "u32",
+///         data: 20000000
+///     }
+/// }
+class SolanaComputeBudgetUnitPriceInstruction extends ASolanaInstructionDecoded {
+  /// Field order on Solscan is based on unknown rules.
+  ///
+  /// Our field order below is NOT influenced by Solscan and follows the order of data received from [SolanaCompiledInstruction]:
+  /// - instruction data array values, in order of appearance in [SolanaCompiledInstruction] data field
+  final int _discriminator;
+  final int _microLamports;
+
+  const SolanaComputeBudgetUnitPriceInstruction({
+    required String programId,
+    required int discriminator,
+    required int microLamports,
+  })  : _discriminator = discriminator,
+        _microLamports = microLamports,
+        super(programId: programId);
+
+  /// Creates a new instance of [SolanaComputeBudgetUnitPriceInstruction] from the serialized data.
+  factory SolanaComputeBudgetUnitPriceInstruction.fromSerializedData(SolanaCompiledInstruction solanaCompiledInstruction, String programId) {
+    ByteData byteData = solanaCompiledInstruction.data.buffer.asByteData();
+    int discriminator = byteData.getUint8(0);
+    int microLamports = byteData.getUint64(1, Endian.little);
+
+    return SolanaComputeBudgetUnitPriceInstruction(
+      programId: programId,
+      discriminator: discriminator,
+      microLamports: microLamports,
+    );
+  }
+
+  @override
+  int? get discriminator => _discriminator;
+
+  @override
+  int? get microLamports => _microLamports;
+
+  @override
+  List<Object?> get props => <Object?>[programId, _discriminator, _microLamports];
+}

--- a/lib/src/transactions/solana/instructions/invalid_instruction/solana_invalid_instruction.dart
+++ b/lib/src/transactions/solana/instructions/invalid_instruction/solana_invalid_instruction.dart
@@ -1,0 +1,11 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// An invalid instruction, created when programId cannot be defined.
+class SolanaInvalidInstruction extends ASolanaInstructionDecoded {
+  const SolanaInvalidInstruction({
+    String programId = '',
+  }) : super(programId: programId);
+
+  @override
+  List<Object?> get props => <Object?>[programId];
+}

--- a/lib/src/transactions/solana/instructions/solana_compiled_instruction.dart
+++ b/lib/src/transactions/solana/instructions/solana_compiled_instruction.dart
@@ -1,0 +1,48 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:equatable/equatable.dart';
+
+/// A directive for a single invocation of a Solana program
+///
+/// https://solana.com/docs/core/transactions#array-of-instructions
+class SolanaCompiledInstruction extends Equatable {
+  /// An index that points to the program's address in the account keys list from [ASolanaTransactionMessage].
+  /// This specifies the program that processes the instruction.
+  final int programIdIndex;
+
+  /// An array of indexes that point to the account addresses in the account keys list which are required for this instruction.
+  /// These indexes point to the addresses in the account keys list from [ASolanaTransactionMessage].
+  final Uint8List accounts;
+
+  /// A byte array that specifies which instruction to invoke on the program and any additional data
+  /// required by the instruction (eg. function arguments).
+  /// The values stored in the byte array are represented in little-endian.
+  /// The byte array usually contains the [discriminator] first, then instruction-specific data (if any is provided).
+  final Uint8List data;
+
+  const SolanaCompiledInstruction({
+    required this.programIdIndex,
+    required this.accounts,
+    required this.data,
+  });
+
+  /// Extracts a [SolanaCompiledInstruction] from a [ByteReader] of a [SolanaLegacyMessage] or a [SolanaV0Message].
+  factory SolanaCompiledInstruction.fromSerializedData(ByteReader byteReader) {
+    int programId = byteReader.shiftRight();
+    int accountCount = CompactU16Decoder.decode(byteReader);
+    Uint8List accounts = byteReader.shiftRightBy(accountCount);
+    int dataLength = CompactU16Decoder.decode(byteReader);
+    Uint8List data = byteReader.shiftRightBy(dataLength);
+
+    return SolanaCompiledInstruction(
+      programIdIndex: programId,
+      accounts: accounts,
+      data: data,
+    );
+  }
+
+  @override
+  List<Object?> get props => <Object?>[programIdIndex, accounts, data];
+}

--- a/lib/src/transactions/solana/instructions/solana_instructions.dart
+++ b/lib/src/transactions/solana/instructions/solana_instructions.dart
@@ -1,0 +1,11 @@
+export 'compute_budget/solana_compute_budget_unit_limit_instruction.dart';
+export 'compute_budget/solana_compute_budget_unit_price_instruction.dart';
+export 'invalid_instruction/solana_invalid_instruction.dart';
+export 'stake_program/solana_stake_deactivate_instruction.dart';
+export 'stake_program/solana_stake_delegate_instruction.dart';
+export 'stake_program/solana_stake_initialize_instruction.dart';
+export 'stake_program/solana_stake_withdraw_instruction.dart';
+export 'system_program/solana_system_account_seed_instruction.dart';
+export 'system_program/solana_system_transfer_instruction.dart';
+export 'token_program/solana_token_transfer_checked_instruction.dart';
+export 'unknown_instruction/solana_unknown_instruction.dart';

--- a/lib/src/transactions/solana/instructions/solana_program_type.dart
+++ b/lib/src/transactions/solana/instructions/solana_program_type.dart
@@ -1,0 +1,19 @@
+enum SolanaProgramType {
+  system('11111111111111111111111111111111'),
+  token('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+  computeBudget('ComputeBudget111111111111111111111111111111'),
+  stake('Stake11111111111111111111111111111111111111');
+
+  const SolanaProgramType(this.value);
+
+  final String value;
+
+  static SolanaProgramType? fromProgramId(String programId) {
+    for (SolanaProgramType solanaProgramType in SolanaProgramType.values) {
+      if (solanaProgramType.value == programId) {
+        return solanaProgramType;
+      }
+    }
+    return null;
+  }
+}

--- a/lib/src/transactions/solana/instructions/stake_program/solana_stake_deactivate_instruction.dart
+++ b/lib/src/transactions/solana/instructions/stake_program/solana_stake_deactivate_instruction.dart
@@ -1,0 +1,73 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// An instruction which deactivates the [stakeAccount] belonging to a [stakeAuthority].
+///
+/// Example instruction: https://solscan.io/tx/4DB2rzhh2KMuRqDu54iW1YWhVMi29cfWnPCXUwWheUbnzaTnyxfHPAyn7jafsFYFPtBpcsFi87ivXcF6LUk8wFJp?cluster=devnet
+/// {
+///   "info": {
+///     "clockSysvar": "SysvarC1ock11111111111111111111111111111111",
+///     "stakeAccount": "CkT3NP8HMam7v73564b638kPBvy8SGTt9mNjuLtRw79k",
+///     "stakeAuthority": "2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19"
+///   },
+///   "type": "deactivate"
+/// }
+class SolanaStakeDeactivateInstruction extends ASolanaInstructionDecoded {
+  /// Field order on Solscan is based on unknown rules.
+  /// Solscan also ignores the [discriminator] for this instruction, even though it is always present in this instruction's data array.
+  ///
+  /// Our field order below is NOT influenced by Solscan and follows the order of data received from [SolanaCompiledInstruction]:
+  /// - account indexes, in order of appearance in the [SolanaCompiledInstruction] accounts field
+  /// - instruction data array values, in order of appearance in [SolanaCompiledInstruction] data field
+  final String _stakeAccount;
+  final String _clockSysvar;
+  final String _stakeAuthority;
+  final int _discriminator;
+
+  const SolanaStakeDeactivateInstruction({
+    required String programId,
+    required String stakeAccount,
+    required String clockSysvar,
+    required String stakeAuthority,
+    required int discriminator,
+  })  : _stakeAccount = stakeAccount,
+        _clockSysvar = clockSysvar,
+        _stakeAuthority = stakeAuthority,
+        _discriminator = discriminator,
+        super(programId: programId);
+
+  /// Creates a new instance of [SolanaStakeDeactivateInstruction] from the serialized data.
+  factory SolanaStakeDeactivateInstruction.fromSerializedData(
+      SolanaCompiledInstruction solanaCompiledInstruction, List<SolanaPubKey> accountKeys, String programId) {
+    String stakeAccount = accountKeys[solanaCompiledInstruction.accounts[0]].toBase58();
+    String clockSysvar = accountKeys[solanaCompiledInstruction.accounts[1]].toBase58();
+    String stakeAuthority = accountKeys[solanaCompiledInstruction.accounts[2]].toBase58();
+
+    ByteData byteData = solanaCompiledInstruction.data.buffer.asByteData();
+    int discriminator = byteData.getUint32(0, Endian.little);
+
+    return SolanaStakeDeactivateInstruction(
+      programId: programId,
+      stakeAccount: stakeAccount,
+      clockSysvar: clockSysvar,
+      stakeAuthority: stakeAuthority,
+      discriminator: discriminator,
+    );
+  }
+
+  @override
+  String? get stakeAccount => _stakeAccount;
+
+  @override
+  String? get clockSysvar => _clockSysvar;
+
+  @override
+  String? get stakeAuthority => _stakeAuthority;
+
+  @override
+  int? get discriminator => _discriminator;
+
+  @override
+  List<Object?> get props => <Object?>[programId, _stakeAccount, _clockSysvar, _stakeAuthority, _discriminator];
+}

--- a/lib/src/transactions/solana/instructions/stake_program/solana_stake_delegate_instruction.dart
+++ b/lib/src/transactions/solana/instructions/stake_program/solana_stake_delegate_instruction.dart
@@ -1,0 +1,109 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// An instruction which delegates a stake to a particular vote account.
+///
+/// Example instruction: https://solscan.io/tx/3nJWhUxPWsEWPDHwcYouu2e5GBRZBBzWS1YS38ENXFY9LL2KHmxWfnfZfTTNZzedZh9HrLPe51rn3h9eTVCAhgpt?cluster=devnet
+/// {
+///   "info": {
+///     "clockSysvar": "SysvarC1ock11111111111111111111111111111111",
+///     "stakeAccount": "CkT3NP8HMam7v73564b638kPBvy8SGTt9mNjuLtRw79k",
+///     "stakeAuthority": "2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19",
+///     "stakeConfigAccount": "StakeConfig11111111111111111111111111111111",
+///     "stakeHistorySysvar": "SysvarStakeHistory1111111111111111111111111",
+///     "voteAccount": "FwR3PbjS5iyqzLiLugrBqKSa5EKZ4vK9SKs7eQXtT59f"
+///   },
+///   "type": "delegate"
+/// }
+class SolanaStakeDelegateInstruction extends ASolanaInstructionDecoded {
+  /// Field order on Solscan is based on unknown rules.
+  /// Solscan also ignores the [discriminator] for this instruction, even though it is always present in this instruction's data array.
+  ///
+  /// Our field order below is NOT influenced by Solscan and follows the order of data received from [SolanaCompiledInstruction]:
+  /// - account indexes, in order of appearance in the [SolanaCompiledInstruction] accounts field
+  /// - instruction data array values, in order of appearance in [SolanaCompiledInstruction] data field
+  final String _stakeAccount;
+  final String _voteAccount;
+  final String _clockSysvar;
+  final String _stakeHistorySysvar;
+  final String _stakeConfigAccount;
+  final String _stakeAuthority;
+  final int _discriminator;
+
+  const SolanaStakeDelegateInstruction({
+    required String programId,
+    required String stakeAccount,
+    required String voteAccount,
+    required String clockSysvar,
+    required String stakeHistorySysvar,
+    required String stakeConfigAccount,
+    required String stakeAuthority,
+    required int discriminator,
+  })  : _stakeAccount = stakeAccount,
+        _voteAccount = voteAccount,
+        _clockSysvar = clockSysvar,
+        _stakeHistorySysvar = stakeHistorySysvar,
+        _stakeConfigAccount = stakeConfigAccount,
+        _stakeAuthority = stakeAuthority,
+        _discriminator = discriminator,
+        super(programId: programId);
+
+  /// Creates a new instance of [SolanaStakeDelegateInstruction] from the serialized data.
+  factory SolanaStakeDelegateInstruction.fromSerializedData(
+      SolanaCompiledInstruction solanaCompiledInstruction, List<SolanaPubKey> accountKeys, String programId) {
+    String stakeAccount = accountKeys[solanaCompiledInstruction.accounts[0]].toBase58();
+    String voteAccount = accountKeys[solanaCompiledInstruction.accounts[1]].toBase58();
+    String clockSysvar = accountKeys[solanaCompiledInstruction.accounts[2]].toBase58();
+    String stakeHistorySysvar = accountKeys[solanaCompiledInstruction.accounts[3]].toBase58();
+    String stakeConfigAccount = accountKeys[solanaCompiledInstruction.accounts[4]].toBase58();
+    String stakeAuthority = accountKeys[solanaCompiledInstruction.accounts[5]].toBase58();
+
+    ByteData byteData = solanaCompiledInstruction.data.buffer.asByteData();
+    int discriminator = byteData.getUint32(0, Endian.little);
+
+    return SolanaStakeDelegateInstruction(
+      programId: programId,
+      stakeAccount: stakeAccount,
+      voteAccount: voteAccount,
+      clockSysvar: clockSysvar,
+      stakeHistorySysvar: stakeHistorySysvar,
+      stakeConfigAccount: stakeConfigAccount,
+      stakeAuthority: stakeAuthority,
+      discriminator: discriminator,
+    );
+  }
+
+  @override
+  String? get stakeAccount => _stakeAccount;
+
+  @override
+  String? get voteAccount => _voteAccount;
+
+  @override
+  String? get clockSysvar => _clockSysvar;
+
+  @override
+  String? get stakeHistorySysvar => _stakeHistorySysvar;
+
+  @override
+  String? get stakeConfigAccount => _stakeConfigAccount;
+
+  @override
+  String? get stakeAuthority => _stakeAuthority;
+
+  @override
+  int? get discriminator => _discriminator;
+
+  @override
+  List<Object?> get props => <Object?>[
+        programId,
+        _stakeAccount,
+        _voteAccount,
+        _clockSysvar,
+        _stakeHistorySysvar,
+        _stakeConfigAccount,
+        _stakeAuthority,
+        _discriminator,
+      ];
+}

--- a/lib/src/transactions/solana/instructions/stake_program/solana_stake_initialize_instruction.dart
+++ b/lib/src/transactions/solana/instructions/stake_program/solana_stake_initialize_instruction.dart
@@ -1,0 +1,123 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// An instruction which initializes a [stakeAccount].
+///
+/// Example instruction: https://solscan.io/tx/3nJWhUxPWsEWPDHwcYouu2e5GBRZBBzWS1YS38ENXFY9LL2KHmxWfnfZfTTNZzedZh9HrLPe51rn3h9eTVCAhgpt?cluster=devnet
+/// {
+///   "info": {
+///     "authorized": {
+///       "staker": "2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19",
+///       "withdrawer": "2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19"
+///     },
+///     "lockup": {
+///       "custodian": "2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19",
+///       "epoch": 0,
+///       "unixTimestamp": 0
+///     },
+///     "rentSysvar": "SysvarRent111111111111111111111111111111111",
+///     "stakeAccount": "CkT3NP8HMam7v73564b638kPBvy8SGTt9mNjuLtRw79k"
+///   },
+///   "type": "initialize"
+/// }
+class SolanaStakeInitializeInstruction extends ASolanaInstructionDecoded {
+  /// Field order on Solscan is based on unknown rules.
+  /// Solscan also ignores the [discriminator] for this instruction, even though it is always present in this instruction's data array.
+  ///
+  /// Our field order below is NOT influenced by Solscan and follows the order of data received from [SolanaCompiledInstruction]:
+  /// - account indexes, in order of appearance in the [SolanaCompiledInstruction] accounts field
+  /// - instruction data array values, in order of appearance in [SolanaCompiledInstruction] data field
+  final String _stakeAccount;
+  final String _rentSysvar;
+  final int _discriminator;
+  final String _staker;
+  final String _withdrawer;
+  final int _unixTimestamp;
+  final int _epoch;
+  final String _custodian;
+
+  const SolanaStakeInitializeInstruction({
+    required String programId,
+    required String stakeAccount,
+    required String rentSysvar,
+    required int discriminator,
+    required String staker,
+    required String withdrawer,
+    required int unixTimestamp,
+    required int epoch,
+    required String custodian,
+  })  : _stakeAccount = stakeAccount,
+        _rentSysvar = rentSysvar,
+        _discriminator = discriminator,
+        _staker = staker,
+        _withdrawer = withdrawer,
+        _unixTimestamp = unixTimestamp,
+        _epoch = epoch,
+        _custodian = custodian,
+        super(programId: programId);
+
+  /// Creates a new instance of [SolanaStakeInitializeInstruction] from the serialized data.
+  factory SolanaStakeInitializeInstruction.fromSerializedData(
+      SolanaCompiledInstruction solanaCompiledInstruction, List<SolanaPubKey> accountKeys, String programId) {
+    String stakeAccount = accountKeys[solanaCompiledInstruction.accounts[0]].toBase58();
+    String rentSysvar = accountKeys[solanaCompiledInstruction.accounts[1]].toBase58();
+
+    ByteData byteData = solanaCompiledInstruction.data.buffer.asByteData();
+    int discriminator = byteData.getUint32(0, Endian.little);
+    String staker = SolanaPubKey.fromBytes(solanaCompiledInstruction.data.sublist(4, 36)).toBase58();
+    String withdrawer = SolanaPubKey.fromBytes(solanaCompiledInstruction.data.sublist(36, 68)).toBase58();
+    int unixTimestamp = byteData.getInt64(68, Endian.little);
+    int epoch = byteData.getUint64(76, Endian.little);
+    String custodian = SolanaPubKey.fromBytes(solanaCompiledInstruction.data.sublist(84, 116)).toBase58();
+
+    return SolanaStakeInitializeInstruction(
+      programId: programId,
+      stakeAccount: stakeAccount,
+      rentSysvar: rentSysvar,
+      discriminator: discriminator,
+      staker: staker,
+      withdrawer: withdrawer,
+      unixTimestamp: unixTimestamp,
+      epoch: epoch,
+      custodian: custodian,
+    );
+  }
+
+  @override
+  String? get stakeAccount => _stakeAccount;
+
+  @override
+  String? get rentSysvar => _rentSysvar;
+
+  @override
+  int? get discriminator => _discriminator;
+
+  @override
+  String? get staker => _staker;
+
+  @override
+  String? get withdrawer => _withdrawer;
+
+  @override
+  int? get unixTimestamp => _unixTimestamp;
+
+  @override
+  int get epoch => _epoch;
+
+  @override
+  String? get custodian => _custodian;
+
+  @override
+  List<Object?> get props => <Object?>[
+        programId,
+        _stakeAccount,
+        _rentSysvar,
+        _discriminator,
+        _staker,
+        _withdrawer,
+        _unixTimestamp,
+        _epoch,
+        _custodian,
+      ];
+}

--- a/lib/src/transactions/solana/instructions/stake_program/solana_stake_withdraw_instruction.dart
+++ b/lib/src/transactions/solana/instructions/stake_program/solana_stake_withdraw_instruction.dart
@@ -1,0 +1,109 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// An instruction which withdraws unstaked lamports from the [stakeAccount].
+///
+/// Example instruction: https://solscan.io/tx/3an1bBo4bpPiKJPTohfMB2TRdGUVTzoT8vpZ1RfHjnaQWH7CRguKogqqfaerYoYTJ7zGi2bhibzpNs8VB274uYLD?cluster=devnet
+/// {
+///   "info": {
+///     "clockSysvar": "SysvarC1ock11111111111111111111111111111111",
+///     "destination": "2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19",
+///     "lamports": 12282880,
+///     "stakeAccount": "CkT3NP8HMam7v73564b638kPBvy8SGTt9mNjuLtRw79k",
+///     "stakeHistorySysvar": "SysvarStakeHistory1111111111111111111111111",
+///     "withdrawAuthority": "2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19"
+///   },
+///   "type": "withdraw"
+/// }
+class SolanaStakeWithdrawInstruction extends ASolanaInstructionDecoded {
+  /// Field order on Solscan is based on unknown rules.
+  /// Solscan also ignores the [discriminator] for this instruction, even though it is always present in this instruction's data array.
+  ///
+  /// Our field order below is NOT influenced by Solscan and follows the order of data received from [SolanaCompiledInstruction]:
+  /// - account indexes, in order of appearance in the [SolanaCompiledInstruction] accounts field
+  /// - instruction data array values, in order of appearance in [SolanaCompiledInstruction] data field
+  final String _stakeAccount;
+  final String _destination;
+  final String _clockSysvar;
+  final String _stakeHistorySysvar;
+  final String _withdrawAuthority;
+  final int _discriminator;
+  final BigInt _lamports;
+
+  const SolanaStakeWithdrawInstruction({
+    required String programId,
+    required String stakeAccount,
+    required String destination,
+    required String clockSysvar,
+    required String stakeHistorySysvar,
+    required String withdrawAuthority,
+    required int discriminator,
+    required BigInt lamports,
+  })  : _stakeAccount = stakeAccount,
+        _destination = destination,
+        _clockSysvar = clockSysvar,
+        _stakeHistorySysvar = stakeHistorySysvar,
+        _withdrawAuthority = withdrawAuthority,
+        _discriminator = discriminator,
+        _lamports = lamports,
+        super(programId: programId);
+
+  /// Creates a new instance of [SolanaStakeWithdrawInstruction] from the serialized data.
+  factory SolanaStakeWithdrawInstruction.fromSerializedData(
+      SolanaCompiledInstruction solanaCompiledInstruction, List<SolanaPubKey> accountKeys, String programId) {
+    String stakeAccount = accountKeys[solanaCompiledInstruction.accounts[0]].toBase58();
+    String destination = accountKeys[solanaCompiledInstruction.accounts[1]].toBase58();
+    String clockSysvar = accountKeys[solanaCompiledInstruction.accounts[2]].toBase58();
+    String stakeHistorySysvar = accountKeys[solanaCompiledInstruction.accounts[3]].toBase58();
+    String withdrawAuthority = accountKeys[solanaCompiledInstruction.accounts[4]].toBase58();
+
+    ByteData byteData = solanaCompiledInstruction.data.buffer.asByteData();
+    int discriminator = byteData.getUint32(0, Endian.little);
+    BigInt lamports = BigInt.from(byteData.getUint64(4, Endian.little));
+
+    return SolanaStakeWithdrawInstruction(
+      programId: programId,
+      stakeAccount: stakeAccount,
+      destination: destination,
+      clockSysvar: clockSysvar,
+      stakeHistorySysvar: stakeHistorySysvar,
+      withdrawAuthority: withdrawAuthority,
+      discriminator: discriminator,
+      lamports: lamports,
+    );
+  }
+
+  @override
+  String? get stakeAccount => _stakeAccount;
+
+  @override
+  String? get destination => _destination;
+
+  @override
+  String? get clockSysvar => _clockSysvar;
+
+  @override
+  String? get stakeHistorySysvar => _stakeHistorySysvar;
+
+  @override
+  String? get withdrawAuthority => _withdrawAuthority;
+
+  @override
+  int? get discriminator => _discriminator;
+
+  @override
+  BigInt? get lamports => _lamports;
+
+  @override
+  List<Object?> get props => <Object?>[
+        programId,
+        _stakeAccount,
+        _destination,
+        _clockSysvar,
+        _stakeHistorySysvar,
+        _withdrawAuthority,
+        _discriminator,
+        _lamports,
+      ];
+}

--- a/lib/src/transactions/solana/instructions/system_program/solana_system_account_seed_instruction.dart
+++ b/lib/src/transactions/solana/instructions/system_program/solana_system_account_seed_instruction.dart
@@ -1,0 +1,128 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// An instruction which creates [newAccount] belonging to [source], generated with [base] and [seed],
+/// paying [lamports] (SOL) which includes both the staked amount as well as a fee for account creation.
+/// The instruction's full name is CreateAccountWithSeed.
+///
+/// Example instruction: https://solscan.io/tx/29paksPao72yNHhfHUuFDgfm9yzQMe5FDzXz9QSTu5AH7TzKerHHKFbdm7mbuxTZP5cqmLdqXAfWhcpdzXRzuTHE?cluster=devnet
+/// {
+///     info: {
+///         base: "2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19"
+///         lamports: 1002282880
+///         newAccount: "M9iFmNtBVXLGKX3MRfApAar1g2PJgGvp9FKrs1Qwimc"
+///         owner: "Stake11111111111111111111111111111111111111"
+///         seed: "stake:3"
+///         source: "2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19"
+///         space: 200
+///     }
+///     type: "createAccountWithSeed"
+/// }
+class SolanaSystemAccountSeedInstruction extends ASolanaInstructionDecoded {
+  /// Field order on Solscan is based on unknown rules.
+  /// Solscan also ignores the [discriminator] for this instruction, even though it is always present in this instruction's data array.
+  ///
+  /// Our field order below is NOT influenced by Solscan and follows the order of data received from [SolanaCompiledInstruction]:
+  /// - account indexes, in order of appearance in the [SolanaCompiledInstruction] accounts field
+  /// - instruction data array values, in order of appearance in [SolanaCompiledInstruction] data field
+  final String _source;
+  final String _newAccount;
+  final int _discriminator;
+  final String _base;
+  final String _seed;
+  final BigInt _lamports;
+  final int _space;
+  final String _owner;
+
+  const SolanaSystemAccountSeedInstruction({
+    required String programId,
+    required String source,
+    required String newAccount,
+    required int discriminator,
+    required String base,
+    required String seed,
+    required BigInt lamports,
+    required int space,
+    required String owner,
+  })  : _source = source,
+        _newAccount = newAccount,
+        _discriminator = discriminator,
+        _base = base,
+        _seed = seed,
+        _lamports = lamports,
+        _space = space,
+        _owner = owner,
+        super(programId: programId);
+
+  /// Creates a new instance of [SolanaSystemAccountSeedInstruction] from the serialized data.
+  factory SolanaSystemAccountSeedInstruction.fromSerializedData(
+      SolanaCompiledInstruction solanaCompiledInstruction, List<SolanaPubKey> accountKeys, String programId) {
+    String source = accountKeys[solanaCompiledInstruction.accounts[0]].toBase58();
+    String newAccount = accountKeys[solanaCompiledInstruction.accounts[1]].toBase58();
+
+    ByteReader byteReader = ByteReader(solanaCompiledInstruction.data);
+
+    Uint8List discriminatorBytes = byteReader.shiftRightBy(4);
+    int discriminator = ByteData.sublistView(discriminatorBytes).getUint32(0, Endian.little);
+
+    Uint8List baseBytes = byteReader.shiftRightBy(32);
+    String base = SolanaPubKey.fromBytes(baseBytes).toBase58();
+
+    Uint8List seedLengthBytes = byteReader.shiftRightBy(8);
+    int seedLength = ByteData.sublistView(seedLengthBytes).getUint32(0, Endian.little);
+    Uint8List seedBytes = byteReader.shiftRightBy(seedLength);
+    String seed = utf8.decode(seedBytes);
+
+    Uint8List lamportsBytes = byteReader.shiftRightBy(8);
+    int lamportsInt = ByteData.sublistView(lamportsBytes).getUint64(0, Endian.little);
+    BigInt lamports = BigInt.from(lamportsInt);
+
+    Uint8List spaceBytes = byteReader.shiftRightBy(8);
+    int space = ByteData.sublistView(spaceBytes).getUint64(0, Endian.little);
+
+    Uint8List ownerBytes = byteReader.shiftRightBy(32);
+    String owner = SolanaPubKey.fromBytes(ownerBytes).toBase58();
+
+    return SolanaSystemAccountSeedInstruction(
+      programId: programId,
+      source: source,
+      newAccount: newAccount,
+      discriminator: discriminator,
+      base: base,
+      seed: seed,
+      lamports: lamports,
+      space: space,
+      owner: owner,
+    );
+  }
+
+  @override
+  String? get source => _source;
+
+  @override
+  String? get newAccount => _newAccount;
+
+  @override
+  int? get discriminator => _discriminator;
+
+  @override
+  String? get base => _base;
+
+  @override
+  String? get seed => _seed;
+
+  @override
+  BigInt? get lamports => _lamports;
+
+  @override
+  int? get space => _space;
+
+  @override
+  String? get owner => _owner;
+
+  @override
+  List<Object?> get props => <Object?>[programId, _source, _newAccount, _discriminator, _base, _seed, _lamports, _space, _owner];
+}

--- a/lib/src/transactions/solana/instructions/system_program/solana_system_transfer_instruction.dart
+++ b/lib/src/transactions/solana/instructions/system_program/solana_system_transfer_instruction.dart
@@ -1,0 +1,73 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// An instruction which transfers [lamports] (SOL) from [source] to [destination].
+///
+/// Example instruction: https://solscan.io/tx/4uyy2M3xF7swQH6ZFbhxfSFLRARqGQMUi65ikzCzcaGWmKR81vubvPcrEQ4yPhaj7MYw3hBow7w9jnFREMDXyfTs?cluster=devnet
+/// {
+///     info: {
+///         destination: "6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z"
+///         lamports: 100000000
+///         source: "2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19"
+///     }
+///     type: "transfer"
+/// }
+class SolanaSystemTransferInstruction extends ASolanaInstructionDecoded {
+  /// Field order on Solscan is based on unknown rules.
+  /// Solscan also ignores the [discriminator] for this instruction, even though it is always present in this instruction's data array.
+  ///
+  /// Our field order below is NOT influenced by Solscan and follows the order of data received from [SolanaCompiledInstruction]:
+  /// - account indexes, in order of appearance in the [SolanaCompiledInstruction] accounts field
+  /// - instruction data array values, in order of appearance in [SolanaCompiledInstruction] data field
+  final String _source;
+  final String _destination;
+  final int _discriminator;
+  final BigInt _lamports;
+
+  const SolanaSystemTransferInstruction({
+    required String programId,
+    required String source,
+    required String destination,
+    required int discriminator,
+    required BigInt lamports,
+  })  : _source = source,
+        _destination = destination,
+        _discriminator = discriminator,
+        _lamports = lamports,
+        super(programId: programId);
+
+  /// Creates a new instance of [SolanaSystemTransferInstruction] from the serialized data.
+  factory SolanaSystemTransferInstruction.fromSerializedData(
+      SolanaCompiledInstruction solanaCompiledInstruction, List<SolanaPubKey> accountKeys, String programId) {
+    String source = accountKeys[solanaCompiledInstruction.accounts[0]].toBase58();
+    String destination = accountKeys[solanaCompiledInstruction.accounts[1]].toBase58();
+
+    ByteData byteData = solanaCompiledInstruction.data.buffer.asByteData();
+    int discriminator = byteData.getUint32(0, Endian.little);
+    BigInt lamports = BigInt.from(byteData.getUint64(4, Endian.little));
+
+    return SolanaSystemTransferInstruction(
+      programId: programId,
+      source: source,
+      destination: destination,
+      discriminator: discriminator,
+      lamports: lamports,
+    );
+  }
+
+  @override
+  String? get source => _source;
+
+  @override
+  String? get destination => _destination;
+
+  @override
+  int? get discriminator => _discriminator;
+
+  @override
+  BigInt? get lamports => _lamports;
+
+  @override
+  List<Object?> get props => <Object?>[programId, _source, _destination, _discriminator, _lamports];
+}

--- a/lib/src/transactions/solana/instructions/token_program/solana_token_transfer_checked_instruction.dart
+++ b/lib/src/transactions/solana/instructions/token_program/solana_token_transfer_checked_instruction.dart
@@ -1,0 +1,104 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// An instruction which transfers a token identified as [mint] from a [source] associated account to a [destination] associated account.
+///
+/// Example instruction: https://solscan.io/tx/5Cx6TSFpNPxG4byh51hx1tdn1S7CZev8NmKuumErgLQxbvV6FVzXcfxF4rmpzpVsQffYb7EsExXiwq3aUMhT8tfE?cluster=devnet
+/// {
+///   "info": {
+///     "authority": "2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19",
+///     "destination": "5RipPdH3QLE7cyKzf7HKDrUoBrPKNi8odK866vJZV3AP",
+///     "mint": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+///     "source": "9UvdRv2CoyLrgdGbobrQu6feMoapdzY1oqueuYMBfLWv",
+///     "tokenAmount": {
+///       "amount": "100000",
+///       "decimals": 6,
+///       "uiAmount": 0.1,
+///       "uiAmountString": "0.1"
+///     }
+///   },
+///   "type": "transferChecked"
+/// }
+class SolanaTokenTransferCheckedInstruction extends ASolanaInstructionDecoded {
+  /// Field order on Solscan is based on unknown rules.
+  /// Solscan also ignores the [discriminator] for this instruction, even though it is always present in this instruction's data array.
+  ///
+  /// Our field order below is NOT influenced by Solscan and follows the order of data received from [SolanaCompiledInstruction]:
+  /// - account indexes, in order of appearance in the [SolanaCompiledInstruction] accounts field
+  /// - instruction data array values, in order of appearance in [SolanaCompiledInstruction] data field
+  final String _source;
+  final String _mint;
+  final String _destination;
+  final String _authority;
+  final int _discriminator;
+  final BigInt _amount;
+  final int _decimals;
+
+  const SolanaTokenTransferCheckedInstruction({
+    required String programId,
+    required String source,
+    required String mint,
+    required String destination,
+    required String authority,
+    required int discriminator,
+    required BigInt amount,
+    required int decimals,
+  })  : _source = source,
+        _mint = mint,
+        _destination = destination,
+        _authority = authority,
+        _discriminator = discriminator,
+        _amount = amount,
+        _decimals = decimals,
+        super(programId: programId);
+
+  /// Creates a new instance of [SolanaTokenTransferCheckedInstruction] from the serialized data.
+  factory SolanaTokenTransferCheckedInstruction.fromSerializedData(
+      SolanaCompiledInstruction solanaCompiledInstruction, List<SolanaPubKey> accountKeys, String programId) {
+    String source = accountKeys[solanaCompiledInstruction.accounts[0]].toBase58();
+    String mint = accountKeys[solanaCompiledInstruction.accounts[1]].toBase58();
+    String destination = accountKeys[solanaCompiledInstruction.accounts[2]].toBase58();
+    String authority = accountKeys[solanaCompiledInstruction.accounts[3]].toBase58();
+
+    ByteData byteData = solanaCompiledInstruction.data.buffer.asByteData();
+    int discriminator = byteData.getUint8(0);
+    BigInt amount = BigInt.from(byteData.getUint64(1, Endian.little));
+    int decimals = byteData.getUint8(9);
+
+    return SolanaTokenTransferCheckedInstruction(
+      programId: programId,
+      source: source,
+      mint: mint,
+      destination: destination,
+      authority: authority,
+      discriminator: discriminator,
+      amount: amount,
+      decimals: decimals,
+    );
+  }
+
+  @override
+  String? get source => _source;
+
+  @override
+  String? get mint => _mint;
+
+  @override
+  String? get destination => _destination;
+
+  @override
+  String? get authority => _authority;
+
+  @override
+  int? get discriminator => _discriminator;
+
+  @override
+  BigInt? get amount => _amount;
+
+  @override
+  int? get decimals => _decimals;
+
+  @override
+  List<Object?> get props => <Object?>[programId, _source, _mint, _destination, _authority, _discriminator, _amount, _decimals];
+}

--- a/lib/src/transactions/solana/instructions/unknown_instruction/solana_unknown_instruction.dart
+++ b/lib/src/transactions/solana/instructions/unknown_instruction/solana_unknown_instruction.dart
@@ -1,0 +1,16 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// An instruction of an unknown type which cannot be decoded
+class SolanaUnknownInstruction extends ASolanaInstructionDecoded {
+  const SolanaUnknownInstruction({
+    required String programId,
+  }) : super(programId: programId);
+
+  /// Creates a new instance of [SolanaUnknownInstruction] from the serialized data with the unknown [programId].
+  factory SolanaUnknownInstruction.fromSerializedData(String programId) {
+    return SolanaUnknownInstruction(programId: programId);
+  }
+
+  @override
+  List<Object?> get props => <Object?>[programId];
+}

--- a/lib/src/transactions/solana/solana_address_lookup_table.dart
+++ b/lib/src/transactions/solana/solana_address_lookup_table.dart
@@ -1,0 +1,47 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/src/transactions/solana/solana_pubkey.dart';
+import 'package:equatable/equatable.dart';
+
+/// Address Lookup Tables, commonly referred to as "lookup tables" or "ALTs" for short,
+/// allow developers to create a collection of related addresses to efficiently load more addresses in a single transaction.
+///
+/// https://solana.com/developers/guides/advanced/lookup-tables
+class SolanaAddressLookupTable extends Equatable {
+  final SolanaPubKey accountKey;
+  final List<int> writableIndexesList;
+  final List<int> readonlyIndexesList;
+
+  const SolanaAddressLookupTable({
+    required this.accountKey,
+    required this.writableIndexesList,
+    required this.readonlyIndexesList,
+  });
+
+  factory SolanaAddressLookupTable.fromSerializedData(ByteReader byteReader) {
+    Uint8List keyBytes = byteReader.shiftRightBy(SolanaPubKey.publicKeyLength);
+    SolanaPubKey pubKey = SolanaPubKey.fromBytes(keyBytes);
+
+    int writableCount = CompactU16Decoder.decode(byteReader);
+    List<int> writableIndexes = List<int>.generate(writableCount, (_) {
+      int index = byteReader.shiftRight();
+      return index;
+    });
+
+    int readonlyCount = CompactU16Decoder.decode(byteReader);
+    List<int> readonlyIndexes = List<int>.generate(readonlyCount, (_) {
+      int index = byteReader.shiftRight();
+      return index;
+    });
+
+    return SolanaAddressLookupTable(
+      accountKey: pubKey,
+      writableIndexesList: writableIndexes,
+      readonlyIndexesList: readonlyIndexes,
+    );
+  }
+
+  @override
+  List<Object?> get props => <Object?>[accountKey, writableIndexesList, readonlyIndexesList];
+}

--- a/lib/src/transactions/solana/solana_legacy_message.dart
+++ b/lib/src/transactions/solana/solana_legacy_message.dart
@@ -1,0 +1,46 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// The transaction message includes the list of instructions to be processed atomically.
+///
+/// https://solana.com/docs/core/transactions#transactions
+class SolanaLegacyMessage extends ASolanaTransactionMessage {
+  const SolanaLegacyMessage({
+    required super.header,
+    required super.accountKeysList,
+    required super.recentBlockhash,
+    required super.compiledInstructions,
+  });
+
+  /// Creates a new instance of [SolanaLegacyMessage] from the serialized data.
+  factory SolanaLegacyMessage.fromSerializedData(Uint8List data) {
+    ByteReader byteReader = ByteReader(data);
+
+    SolanaMessageHeader solanaMessageHeader = SolanaMessageHeader.fromBytes(byteReader);
+
+    int accountsCount = CompactU16Decoder.decode(byteReader);
+    List<SolanaPubKey> accountKeysList = List<SolanaPubKey>.generate(accountsCount, (_) {
+      Uint8List keyUint8List = byteReader.shiftRightBy(SolanaPubKey.publicKeyLength);
+      return SolanaPubKey.fromBytes(keyUint8List);
+    });
+
+    Uint8List recentBlockhash = byteReader.shiftRightBy(SolanaPubKey.publicKeyLength);
+
+    int instructionCount = CompactU16Decoder.decode(byteReader);
+    List<SolanaCompiledInstruction> instructionsList = List<SolanaCompiledInstruction>.generate(instructionCount, (_) {
+      return SolanaCompiledInstruction.fromSerializedData(byteReader);
+    });
+
+    return SolanaLegacyMessage(
+      header: solanaMessageHeader,
+      accountKeysList: accountKeysList,
+      recentBlockhash: recentBlockhash,
+      compiledInstructions: instructionsList,
+    );
+  }
+
+  @override
+  List<Object?> get props => <Object?>[header, accountKeysList, recentBlockhash, compiledInstructions];
+}

--- a/lib/src/transactions/solana/solana_message_header.dart
+++ b/lib/src/transactions/solana/solana_message_header.dart
@@ -1,0 +1,36 @@
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:equatable/equatable.dart';
+
+/// The message header specifies the permissions for the account in the transaction.
+/// It works in combination with the strictly ordered account addresses to determine which accounts are signers and which are writable.
+///
+/// https://solana.com/docs/core/transactions#message-header
+class SolanaMessageHeader extends Equatable {
+  /// The number of signatures required for all instructions on the transaction.
+  final int numRequiredSignatures;
+
+  /// The number of signed accounts that are read-only.
+  final int numReadonlySignedAccounts;
+
+  /// The number of unsigned accounts that are read-only.
+  final int numReadonlyUnsignedAccounts;
+
+  const SolanaMessageHeader({
+    required this.numRequiredSignatures,
+    required this.numReadonlySignedAccounts,
+    required this.numReadonlyUnsignedAccounts,
+  });
+
+  /// Extracts a [SolanaMessageHeader] from a [ByteReader] of a [SolanaLegacyMessage] or a [SolanaV0Message].
+  factory SolanaMessageHeader.fromBytes(ByteReader reader) {
+    return SolanaMessageHeader(
+      numRequiredSignatures: reader.shiftRight(),
+      numReadonlySignedAccounts: reader.shiftRight(),
+      numReadonlyUnsignedAccounts: reader.shiftRight(),
+    );
+  }
+
+  @override
+  List<Object?> get props => <Object?>[numRequiredSignatures, numReadonlySignedAccounts, numReadonlyUnsignedAccounts];
+}

--- a/lib/src/transactions/solana/solana_pubkey.dart
+++ b/lib/src/transactions/solana/solana_pubkey.dart
@@ -1,0 +1,36 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:equatable/equatable.dart';
+
+/// An account's public key.
+///
+/// https://solana.com/docs/core/transactions#accountmeta
+class SolanaPubKey extends Equatable {
+  static const int publicKeyLength = 32;
+
+  final Uint8List _bytes;
+
+  const SolanaPubKey(Uint8List bytes) : _bytes = bytes;
+
+  /// Decodes Base58-encoded data and creates a new instance of [SolanaPubKey] from bytes.
+  factory SolanaPubKey.fromBase58(String base58) {
+    Uint8List decodedBytes = Base58Codec.decode(base58);
+    return SolanaPubKey.fromBytes(decodedBytes);
+  }
+
+  /// Creates a new instance of [SolanaPubKey] from bytes.
+  factory SolanaPubKey.fromBytes(Uint8List bytes) {
+    if (bytes.length != publicKeyLength) {
+      throw Exception('Solana public key must be 32 bytes');
+    }
+    return SolanaPubKey(bytes);
+  }
+
+  Uint8List get bytes => _bytes;
+
+  String toBase58() => Base58Codec.encode(_bytes);
+
+  @override
+  List<Object?> get props => <Object?>[_bytes];
+}

--- a/lib/src/transactions/solana/solana_raw_message.dart
+++ b/lib/src/transactions/solana/solana_raw_message.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+
+/// The [SolanaRawMessage] class encapsulates the details required to
+/// create a raw transaction on the Solana blockchain. This class is typically
+/// used for transactions involving raw bytes, such as personal messages or data
+/// payloads.
+class SolanaRawMessage extends ASolanaMessage {
+  /// The raw transaction data.
+  final Uint8List data;
+
+  /// Decodes the serialized data into an instance of [SolanaRawMessage].
+  const SolanaRawMessage.fromSerializedData(this.data);
+
+  /// Serializes the transaction into a byte array.
+  Uint8List serialize() {
+    return Uint8List.fromList(data);
+  }
+
+  /// Returns the message contained in the transaction data.
+  @override
+  String get message {
+    return ascii.decode(data);
+  }
+
+  @override
+  List<Object?> get props => <Object>[data];
+}

--- a/lib/src/transactions/solana/solana_v0_message.dart
+++ b/lib/src/transactions/solana/solana_v0_message.dart
@@ -1,0 +1,64 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:cryptography_utils/src/transactions/solana/solana_address_lookup_table.dart';
+
+/// Versioned Transactions are the new transaction format that allow for additional functionality in the Solana runtime,
+/// including Address Lookup Tables.
+///
+/// https://solana.com/developers/guides/advanced/versions
+class SolanaV0Message extends ASolanaTransactionMessage {
+  /// A collection of related addresses
+  final List<SolanaAddressLookupTable> addressLookupTableList;
+
+  const SolanaV0Message({
+    required super.header,
+    required super.accountKeysList,
+    required super.recentBlockhash,
+    required super.compiledInstructions,
+    required this.addressLookupTableList,
+  });
+
+  /// Creates a new instance of [SolanaV0Message] from the serialized data.
+  factory SolanaV0Message.fromSerializedData(Uint8List data) {
+    ByteReader byteReader = ByteReader(data);
+
+    int versionByte = byteReader.shiftRight();
+    int version = versionByte & 0x7F;
+    if (version != 0) {
+      throw Exception('Only version 0 is supported');
+    }
+
+    SolanaMessageHeader solanaMessageHeader = SolanaMessageHeader.fromBytes(byteReader);
+
+    int accountsCount = CompactU16Decoder.decode(byteReader);
+    List<SolanaPubKey> accountKeys = List<SolanaPubKey>.generate(accountsCount, (_) {
+      Uint8List keyUint8List = byteReader.shiftRightBy(SolanaPubKey.publicKeyLength);
+      return SolanaPubKey(keyUint8List);
+    });
+
+    Uint8List recentBlockhash = byteReader.shiftRightBy(SolanaPubKey.publicKeyLength);
+
+    int instructionCount = CompactU16Decoder.decode(byteReader);
+    List<SolanaCompiledInstruction> instructionsList = List<SolanaCompiledInstruction>.generate(instructionCount, (_) {
+      return SolanaCompiledInstruction.fromSerializedData(byteReader);
+    });
+
+    int addressLookupCount = CompactU16Decoder.decode(byteReader);
+    List<SolanaAddressLookupTable> addressLookupTablesList = List<SolanaAddressLookupTable>.generate(addressLookupCount, (_) {
+      return SolanaAddressLookupTable.fromSerializedData(byteReader);
+    });
+
+    return SolanaV0Message(
+      header: solanaMessageHeader,
+      accountKeysList: accountKeys,
+      recentBlockhash: recentBlockhash,
+      compiledInstructions: instructionsList,
+      addressLookupTableList: addressLookupTablesList,
+    );
+  }
+
+  @override
+  List<Object?> get props => <Object?>[header, accountKeysList, recentBlockhash, compiledInstructions, addressLookupTableList];
+}

--- a/lib/src/utils/solana_utils.dart
+++ b/lib/src/utils/solana_utils.dart
@@ -1,0 +1,14 @@
+import 'package:decimal/decimal.dart';
+
+class SolanaUtils {
+  static const String solSymbol = 'SOL';
+
+  static Decimal parseTokenAmount(BigInt tokenAmount, int tokenDecimalPrecision) {
+    if (tokenAmount == BigInt.zero) {
+      return Decimal.zero;
+    }
+    Decimal tokenAmountDecimal = Decimal.fromBigInt(tokenAmount);
+    Decimal baseUnitsInToken = Decimal.parse('1${'0' * tokenDecimalPrecision}');
+    return (tokenAmountDecimal / baseUnitsInToken).toDecimal();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cryptography_utils
 description: "Dart package containing utility methods for common cryptographic and blockchain-specific operations"
 publish_to: none
-version: 0.0.28
+version: 0.0.29
 
 environment:
   sdk: ">=3.2.6"

--- a/test/signer/solana/solana_signature_test.dart
+++ b/test/signer/solana/solana_signature_test.dart
@@ -1,0 +1,103 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SolanaSignature.fromBytes() constructor', () {
+    test('Should [return SolanaSignature] from valid bytes', () {
+      // Act
+      SolanaSignature actualSolanaSignature =
+          SolanaSignature.fromBytes(base64Decode('B6bf/7+9xWMLqcG009IXRCk1ZfQQVLplnnToC+b7rDb1RB5jkG7OW7SfOGXWAYr3taQoOXmN2phFKFqsY2fnBA=='));
+
+      // Assert
+      SolanaSignature expectedSolanaSignature = SolanaSignature(
+        r: base64Decode('B6bf/7+9xWMLqcG009IXRCk1ZfQQVLplnnToC+b7rDY='),
+        s: base64Decode('9UQeY5Buzlu0nzhl1gGK97WkKDl5jdqYRSharGNn5wQ='),
+      );
+
+      expect(actualSolanaSignature, expectedSolanaSignature);
+    });
+
+    test('Should [throw FormatException] when bytes length is not 64', () {
+      // Arrange
+      Uint8List actualSolanaSignatureBytes = base64Decode('B6bf/7+9xWMLqcG009IXRCk1ZfQQVLplnnToC+b7rDb1RB5jkG7OW7SfOGXWAYr3taQoOXmN2phFKFqsY2fn');
+
+      // Assert
+      expect(() => SolanaSignature.fromBytes(actualSolanaSignatureBytes), throwsFormatException);
+    });
+  });
+
+  group('Tests of SolanaSignature.bytes getter', () {
+    test('Should [return bytes] representing a SolanaSignature', () {
+      // Arrange
+      SolanaSignature actualSolanaSignature =
+          SolanaSignature.fromBytes(base64Decode('B6bf/7+9xWMLqcG009IXRCk1ZfQQVLplnnToC+b7rDb1RB5jkG7OW7SfOGXWAYr3taQoOXmN2phFKFqsY2fnBA=='));
+
+      // Act
+      Uint8List actualSolanaSignatureBytes = actualSolanaSignature.bytes;
+
+      // Assert
+      Uint8List expectedSolanaSignatureBytes =
+          base64Decode('B6bf/7+9xWMLqcG009IXRCk1ZfQQVLplnnToC+b7rDb1RB5jkG7OW7SfOGXWAYr3taQoOXmN2phFKFqsY2fnBA==');
+
+      expect(actualSolanaSignatureBytes, expectedSolanaSignatureBytes);
+    });
+  });
+
+  group('Tests of SolanaSignature.base64 getter', () {
+    test('Should [return base64 string] representing Solana signature', () {
+      // Arrange
+      SolanaSignature actualSolanaSignature = SolanaSignature(
+        r: base64Decode('B6bf/7+9xWMLqcG009IXRCk1ZfQQVLplnnToC+b7rDY='),
+        s: base64Decode('9UQeY5Buzlu0nzhl1gGK97WkKDl5jdqYRSharGNn5wQ='),
+      );
+
+      // Act
+      String actualSolanaSignatureBase64 = actualSolanaSignature.base64;
+
+      // Assert
+      String expectedSolanaSignatureBase64 = 'B6bf/7+9xWMLqcG009IXRCk1ZfQQVLplnnToC+b7rDb1RB5jkG7OW7SfOGXWAYr3taQoOXmN2phFKFqsY2fnBA==';
+
+      expect(actualSolanaSignatureBase64, expectedSolanaSignatureBase64);
+    });
+  });
+
+  group('Tests of SolanaSignature.hex getter', () {
+    test('Should [return HEX string] representing Solana signature', () {
+      // Arrange
+      SolanaSignature actualSolanaSignature = SolanaSignature(
+        r: base64Decode('B6bf/7+9xWMLqcG009IXRCk1ZfQQVLplnnToC+b7rDY='),
+        s: base64Decode('9UQeY5Buzlu0nzhl1gGK97WkKDl5jdqYRSharGNn5wQ='),
+      );
+
+      // Act
+      String actualSolanaSignatureHex = actualSolanaSignature.hex;
+
+      // Assert
+      String expectedSolanaSignatureHex =
+          '0x07a6dfffbfbdc5630ba9c1b4d3d21744293565f41054ba659e74e80be6fbac36f5441e63906ece5bb49f3865d6018af7b5a42839798dda9845285aac6367e704';
+
+      expect(actualSolanaSignatureHex, expectedSolanaSignatureHex);
+    });
+  });
+
+  group('Tests of SolanaSignature.length getter', () {
+    test('Should [return length] of Solana signature', () {
+      // Arrange
+      SolanaSignature actualSolanaSignature = SolanaSignature(
+        r: base64Decode('B6bf/7+9xWMLqcG009IXRCk1ZfQQVLplnnToC+b7rDY='),
+        s: base64Decode('9UQeY5Buzlu0nzhl1gGK97WkKDl5jdqYRSharGNn5wQ='),
+      );
+
+      // Act
+      int actualLength = actualSolanaSignature.length;
+
+      // Assert
+      int expectedLength = 64;
+
+      expect(actualLength, expectedLength);
+    });
+  });
+}

--- a/test/signer/solana/solana_signer_test.dart
+++ b/test/signer/solana/solana_signer_test.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SolanaSigner.sign()', () {
+    test('Should [return SolanaSignature] representing proof of signing message with a given private key', () {
+      // Arrange
+      ED25519PrivateKey actualEd25519PrivateKey = ED25519PrivateKey(
+        edPrivateKey: EDPrivateKey.fromBytes(base64Decode('NgMOPT1ktg0VhawjCrTJkXT+27o7jzci+aN8Z80KsaY=')),
+        metadata: Bip32KeyMetadata.fromCompressedPublicKey(
+          compressedPublicKey: EDPrivateKey.fromBytes(base64Decode('NgMOPT1ktg0VhawjCrTJkXT+27o7jzci+aN8Z80KsaY=')).edPublicKey.bytes,
+        ),
+      );
+
+      // Act
+      SolanaSignature actualSolanaSignature = SolanaSigner(actualEd25519PrivateKey).sign(base64Decode(
+          'AQACBB0D1AEIXs5Rz43yeayo7W0tSpSEF7kNTRVAVF4UGFj0UZgIBV3jdeGVGJKrsLg0H3NjL/I/lmh3OjD0yjTNe1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMGRm/lIRcy/+ytunLDm+e8jOW7xfcSayxDmzpAAAAAPwED+D6bid8Qm8XNAPnvCc2lPDE9RQPiygKW4Pk3jYMDAwAJAwAtMQEAAAAAAwAFAu8BAAACAgABDAIAAAAAypo7AAAAAA=='));
+
+      // Assert
+      SolanaSignature expectedSolanaSignature = SolanaSignature(
+        r: base64Decode('IjBdnh1Hp+g41m5oY/q6am1JLQGGip9zShFTG1QlHbs='),
+        s: base64Decode('DxrAzRG+Iyd499E1lR9helUtxWT23tnpicomjYe2Lgw='),
+      );
+
+      expect(actualSolanaSignature, expectedSolanaSignature);
+    });
+  });
+}

--- a/test/transactions/solana/a_solana_message_test.dart
+++ b/test/transactions/solana/a_solana_message_test.dart
@@ -1,0 +1,126 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:cryptography_utils/src/transactions/solana/solana_address_lookup_table.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of ASolanaMessage.fromSerializedData()', () {
+    test('Should [return SolanaLegacyMessage] when given legacy message with SignDataType.typedTransaction', () {
+      // Act
+      ASolanaMessage actualSolanaLegacyMessage = ASolanaMessage.fromSerializedData(
+        SignDataType.typedTransaction,
+        base64Decode(
+          'AQACBB0D1AEIXs5Rz43yeayo7W0tSpSEF7kNTRVAVF4UGFj0UZgIBV3jdeGVGJKrsLg0H3NjL/I/lmh3OjD0yjTNe1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMGRm/lIRcy/+ytunLDm+e8jOW7xfcSayxDmzpAAAAAvsFnx3LCWACVgkEemZnhkUpLl9hJ7zvQyrFIrH+YayoDAwAJAwAtMQEAAAAAAwAFAu8BAAACAgABDAIAAAAAypo7AAAAAA==',
+        ),
+      );
+
+      // Assert
+      SolanaLegacyMessage expectedSolanaLegacyMessage = SolanaLegacyMessage(
+        header: const SolanaMessageHeader(numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 2),
+        accountKeysList: <SolanaPubKey>[
+          SolanaPubKey(base64Decode('HQPUAQhezlHPjfJ5rKjtbS1KlIQXuQ1NFUBUXhQYWPQ=')),
+          SolanaPubKey(base64Decode('UZgIBV3jdeGVGJKrsLg0H3NjL/I/lmh3OjD0yjTNe1w=')),
+          SolanaPubKey(base64Decode('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=')),
+          SolanaPubKey(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA='))
+        ],
+        recentBlockhash: base64Decode('vsFnx3LCWACVgkEemZnhkUpLl9hJ7zvQyrFIrH+Yayo='),
+        compiledInstructions: <SolanaCompiledInstruction>[
+          SolanaCompiledInstruction(programIdIndex: 3, accounts: Uint8List(0), data: Uint8List.fromList(<int>[3, 0, 45, 49, 1, 0, 0, 0, 0])),
+          SolanaCompiledInstruction(programIdIndex: 3, accounts: Uint8List(0), data: Uint8List.fromList(<int>[2, 239, 1, 0, 0])),
+          SolanaCompiledInstruction(
+              programIdIndex: 2, accounts: Uint8List.fromList(<int>[0, 1]), data: Uint8List.fromList(<int>[2, 0, 0, 0, 0, 202, 154, 59, 0, 0, 0, 0]))
+        ],
+      );
+
+      expect(actualSolanaLegacyMessage, expectedSolanaLegacyMessage);
+    });
+
+    test('Should [return SolanaV0Message] when given version 0 data with SignDataType.rawBytes', () {
+      // Act
+      ASolanaMessage actualSolanaV0Message = ASolanaMessage.fromSerializedData(
+        SignDataType.rawBytes,
+        base64Decode(
+          'gAEACRCsVML2Bg3dHy0Va9dcV1Z/NhGHyVYhJ0jE+0MRGFemVlZ3NFh19IgWu+pj5UeQzMrHbNYffxTTr/qv3cxI4kqkZn/LU4VSNrEZJg9hJjEvfwMjmNLCvJDpEyG0zH7Y1yRxM32R3yvnX/HBzojB9fApPOfuRWL27j4EX6B/qtMR3YqLvMXqaJtR7xJ7zz/wsSOSpUxQmyAwTUxIhtPBZFuDzN/gj1H6SStJcojxfyVSBM4CsNHf9s8Fuywijv3R7Szf79GhSuUqLOYVkL1+ideK6TTiYEoL0lh29rNcfXJYfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAAEedVb8jHAbu50xW7OaBUH/bGy3qP0jlECsc2iVrwTjwbd9uHXZaGT2cvhRs7reawctIXtX1s3kTqM9YV+/wCpUmHRSqzFvA7sY12ocFofcKOe41qazwv48izGzkkBnXqMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WZqAC/9MhzaIlsIPwUBz6/HLWqN1/oH+Tb3IK6Tft154tD/6J/XX9kp0wJsfKVh53ksJqzbfyd1RSzIap7OM5ejnStls42Wf0xNRAChL93gEW4UQqPNOSYySLu5vwwX4aYsnkR0YRptLIlfQajrMt0F6AtCnIcxppx3jdg3dGvKxBwgABQLGggMACAAJA1IqNQAAAAAADAYABAAXBwoBAQcCAAQMAgAAAM8ntAgAAAAACgEEAREJJwoNAAQDAgUXGgYJDgkZEg8LEBEDARMTGA0KGRUPCxYUAgETExMNCirBIJszQdacgQICAAAAOgFkAAE6AGQBAs8ntAgAAAAACKmKAQAAAAAyAFAKAwQAAAEJAsFXUcXB+MMMeYa6oBoJLmvxqJ7+KcwGc/y1N+Qd8kpZBHd2eHkEBnp1Uxbx7FnCE40ksuuuv14pM6i4jtdWtEsGPK0+XdwvqvOLA76/uwA=',
+        ),
+      );
+
+      // Assert
+      SolanaV0Message expectedSolanaV0Message = SolanaV0Message(
+        header: const SolanaMessageHeader(numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 9),
+        accountKeysList: <SolanaPubKey>[
+          SolanaPubKey.fromBase58('Cbi65bkTUnJWG8uesnCHg2gAEj4ujeD1SamJPe78fdq7'),
+          SolanaPubKey.fromBase58('6pXVFSACE5BND2C3ibGRWMG1fNtV7hfynWrfNKtCXhN3'),
+          SolanaPubKey.fromBase58('7u7cD7NxcZEuzRCBaYo8uVpotRdqZwez47vvuwzCov43'),
+          SolanaPubKey.fromBase58('8ctcHN52LY21FEipCjr1MVWtoZa1irJQTPyAaTj72h7S'),
+          SolanaPubKey.fromBase58('AKpr7UPK7JdQ1BjqkNmo1HQUMwve8EW6EZQhZRbiHPPY'),
+          SolanaPubKey.fromBase58('EnkAmi1xfv2rFnuU26uKn1jnAaKrg2CET3L6oF6r4Nh1'),
+          SolanaPubKey.fromBase58('G5A1npyNuMZ69GNjLTidScK42z3UZNJsmDprHfnrhCcM'),
+          SolanaPubKey.fromBase58('11111111111111111111111111111111'),
+          SolanaPubKey.fromBase58('ComputeBudget111111111111111111111111111111'),
+          SolanaPubKey.fromBase58('JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4'),
+          SolanaPubKey.fromBase58('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+          SolanaPubKey.fromBase58('6YawcNeZ74tRyCv4UfGydYMr7eho7vbUR6ScVffxKAb3'),
+          SolanaPubKey.fromBase58('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'),
+          SolanaPubKey.fromBase58('BQ72nSv9f3PRyRKCBnHLVrerrv37CYTHm5h3s9VSGQDV'),
+          SolanaPubKey.fromBase58('D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf'),
+          SolanaPubKey.fromBase58('GZsNmWKbqhMYtdSkkvMdEyQF9k5mLmP7tTKYWZjcHVPE')
+        ],
+        recentBlockhash: base64Decode('iyeRHRhGm0siV9BqOsy3QXoC0KchzGmnHeN2Dd0a8rE='),
+        compiledInstructions: <SolanaCompiledInstruction>[
+          SolanaCompiledInstruction(programIdIndex: 8, accounts: Uint8List(0), data: Uint8List.fromList(<int>[2, 198, 130, 3, 0])),
+          SolanaCompiledInstruction(programIdIndex: 8, accounts: Uint8List(0), data: Uint8List.fromList(<int>[3, 82, 42, 53, 0, 0, 0, 0, 0])),
+          SolanaCompiledInstruction(programIdIndex: 12, accounts: Uint8List.fromList(<int>[0, 4, 0, 23, 7, 10]), data: Uint8List.fromList(<int>[1])),
+          SolanaCompiledInstruction(
+              programIdIndex: 7, accounts: Uint8List.fromList(<int>[0, 4]), data: Uint8List.fromList(<int>[2, 0, 0, 0, 207, 39, 180, 8, 0, 0, 0, 0])),
+          SolanaCompiledInstruction(programIdIndex: 10, accounts: Uint8List.fromList(<int>[4]), data: Uint8List.fromList(<int>[17])),
+          SolanaCompiledInstruction(
+            programIdIndex: 9,
+            accounts: base64Decode('Cg0ABAMCBRcaBgkOCRkSDwsQEQMBExMYDQoZFQ8LFhQCARMTEw0K'),
+            data: base64Decode('wSCbM0HWnIECAgAAADoBZAABOgBkAQLPJ7QIAAAAAAipigEAAAAAMgBQ'),
+          ),
+          SolanaCompiledInstruction(programIdIndex: 10, accounts: Uint8List.fromList(<int>[4, 0, 0]), data: Uint8List.fromList(<int>[9])),
+        ],
+        addressLookupTableList: <SolanaAddressLookupTable>[
+          SolanaAddressLookupTable(
+              accountKey: SolanaPubKey.fromBytes(base64Decode('wVdRxcH4wwx5hrqgGgkua/Gonv4pzAZz/LU35B3ySlk=')),
+              writableIndexesList: const <int>[119, 118, 120, 121],
+              readonlyIndexesList: const <int>[6, 122, 117, 83]),
+          SolanaAddressLookupTable(
+              accountKey: SolanaPubKey.fromBytes(base64Decode('FvHsWcITjSSy666/XikzqLiO11a0SwY8rT5d3C+q84s=')),
+              readonlyIndexesList: const <int>[],
+              writableIndexesList: const <int>[190, 191, 187])
+        ],
+      );
+
+      expect(actualSolanaV0Message, expectedSolanaV0Message);
+    });
+
+    test('Should [return SolanaRawMessage] when given raw message bytes with SignDataType.rawBytes', () {
+      // Act
+      ASolanaMessage actualSolanaRawMessage = ASolanaMessage.fromSerializedData(
+          SignDataType.rawBytes,
+          base64Decode(
+            'b3BlbnNlYS5pbyB3YW50cyB5b3UgdG8gc2lnbiBpbiB3aXRoIHlvdXIgYWNjb3VudDoKNlZXVXRRaUViU1h5NnZpWGt4czd4eXdldlFKWHJ1VkQxTm1oWDRha2RDMVoKCkNsaWNrIHRvIHNpZ24gaW4gYW5kIGFjY2VwdCB0aGUgT3BlblNlYSBUZXJtcyBvZiBTZXJ2aWNlIChodHRwczovL29wZW5zZWEuaW8vdG9zKSBhbmQgUHJpdmFjeSBQb2xpY3kgKGh0dHBzOi8vb3BlbnNlYS5pby9wcml2YWN5KS4KClVSSTogaHR0cHM6Ly9vcGVuc2VhLmlvLwpWZXJzaW9uOiAxCkNoYWluIElEOiAxCk5vbmNlOiBncThjcDI4aW5uODlyZ3ZhaG91c2QycXMzMwpJc3N1ZWQgQXQ6IDIwMjUtMDgtMjVUMTY6MjU6MzkuMzI5Wg==',
+          ));
+
+      // Assert
+      SolanaRawMessage expectedSolanaRawMessage = SolanaRawMessage.fromSerializedData(base64Decode(
+        'b3BlbnNlYS5pbyB3YW50cyB5b3UgdG8gc2lnbiBpbiB3aXRoIHlvdXIgYWNjb3VudDoKNlZXVXRRaUViU1h5NnZpWGt4czd4eXdldlFKWHJ1VkQxTm1oWDRha2RDMVoKCkNsaWNrIHRvIHNpZ24gaW4gYW5kIGFjY2VwdCB0aGUgT3BlblNlYSBUZXJtcyBvZiBTZXJ2aWNlIChodHRwczovL29wZW5zZWEuaW8vdG9zKSBhbmQgUHJpdmFjeSBQb2xpY3kgKGh0dHBzOi8vb3BlbnNlYS5pby9wcml2YWN5KS4KClVSSTogaHR0cHM6Ly9vcGVuc2VhLmlvLwpWZXJzaW9uOiAxCkNoYWluIElEOiAxCk5vbmNlOiBncThjcDI4aW5uODlyZ3ZhaG91c2QycXMzMwpJc3N1ZWQgQXQ6IDIwMjUtMDgtMjVUMTY6MjU6MzkuMzI5Wg==',
+      ));
+
+      expect(actualSolanaRawMessage, expectedSolanaRawMessage);
+    });
+
+    test('Should [throw Exception] when given data with transaction version 1 tag and SignDataType.typedTransaction', () {
+      // Arrange
+      Uint8List actualSolanaV1Message = base64Decode(
+        'gQEACRCsVML2Bg3dHy0Va9dcV1Z/NhGHyVYhJ0jE+0MRGFemVlZ3NFh19IgWu+pj5UeQzMrHbNYffxTTr/qv3cxI4kqkZn/LU4VSNrEZJg9hJjEvfwMjmNLCvJDpEyG0zH7Y16FK5Sos5hWQvX6J14rpNOJgSgvSWHb2s1x9clh+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAAEedVb8jHAbu50xW7OaBUH/bGy3qP0jlECsc2iVrwTjwbd9uHXZaGT2cvhRs7reawctIXtX1s3kTqM9YV+/wCpUmHRSqzFvA7sY12ocFofcKOe41qazwv48izGzkkBnXqMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WZqAC/9MhzaIlsIPwUBz6/HLWqN1/oH+Tb3IK6Tft154tD/6J/XX9kp0wJsfKVh53ksJqzbfyd1RSzIap7OM5ejnStls42Wf0xNRAChL93gEW4UQqPNOSYySLu5vwwX4aYsnkR0YRptLIlfQajrMt0F6AtCnIcxppx3jdg3dGvKxBwgABQLGggMACAAJA1IqNQAAAAAMBgAEABcHCgEBBwIABAwCAAAAzye0CAAAAAAKAQQBEQknCg0ABAMCBRcaBgkOCRkSDwsQEQMBExMYDQoZFQ8LFhQCARMTEw0KKsEgmzNB1pyBAgIAAAA6AWQAAToAZAECzye0CAAAAAAIqYoBAAAAADIAUAoDBAAAAQkCwVdRxcH4wwx5hrqgGgkua/Gonv4pzAZz/LU35B3ySlkEd3Z4eQQGenVTFvHsWcITjSSy666/XikzqLiO11a0SwY8rT5d3C+q84sDvr+7AA==',
+      );
+
+      // Assert
+      expect(() => ASolanaMessage.fromSerializedData(SignDataType.typedTransaction, actualSolanaV1Message), throwsA(isA<Exception>()));
+    });
+  });
+}

--- a/test/transactions/solana/instructions/a_solana_instruction_decoded_test.dart
+++ b/test/transactions/solana/instructions/a_solana_instruction_decoded_test.dart
@@ -1,0 +1,1073 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:decimal/decimal.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of ASolanaInstructionDecoded.decode()', () {
+    group('Tests of ASolanaInstructionDecoded.decode() - default path', () {
+      test('Should [return SolanaUnknownInstruction] from an instruction with an unknown programId', () {
+        // Act
+        ASolanaInstructionDecoded actualSolanaUnknownInstruction = ASolanaInstructionDecoded.decode(
+          SolanaCompiledInstruction(
+            programIdIndex: 1,
+            accounts: Uint8List.fromList(<int>[0, 1]),
+            data: base64Decode(
+                'AQAAAFGYCAVd43XhlRiSq7C4NB9zYy/yP5Zodzow9Mo0zXtcBwAAAAAAAABzdGFrZTowyAiZOwAAAADIAAAAAAAAAAah2BeRN1QqmDQ3vf4qerJVf1NcinhyK2ikncAAAAAA'),
+          ),
+          <SolanaPubKey>[
+            SolanaPubKey.fromBytes(base64Decode('UZgIBV3jdeGVGJKrsLg0H3NjL/I/lmh3OjD0yjTNe1w=')),
+            SolanaPubKey.fromBytes(base64Decode('wz8cu0jrS8Gt71lzlkKPUyLwd3Wq/J2JWjpRn93SKpY=')),
+            SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqHYF5E3VCqYNDe9/ip6slV/U1yKeHIraKSdwAAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxksXFEhjMlMPUrxf1ja7gibof1E49vZigAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('3fQqBIAKVN4uWD+U8XsIlyW3ctEzNSYnEkFTJ3bS/8Y=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxk1hND+7ZuzQx0TIGvlRCgbV7hWbMU3X/QAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqHYF6UCBQtoB5Hmzm24jh5bcVD2H8Z5Ck600QAAAAA=')),
+          ],
+        );
+
+        // Assert
+        SolanaUnknownInstruction expectedSolanaUnknownInstruction =
+            const SolanaUnknownInstruction(programId: 'E9AKSDnvxFcUrvMqRVrANNZ2qdidh4AC1niGhQ6vGZxR');
+
+        expect(actualSolanaUnknownInstruction, expectedSolanaUnknownInstruction);
+      });
+
+      test('Should [return SolanaUnknownInstruction] from an instruction with an unknown programId', () {
+        // Act
+        ASolanaInstructionDecoded actualSolanaUnknownInstruction = ASolanaInstructionDecoded.decode(
+          SolanaCompiledInstruction(
+            programIdIndex: 1,
+            accounts: Uint8List.fromList(<int>[0, 1]),
+            data: base64Decode(
+                'AQAAAFGYCAVd43XhlRiSq7C4NB9zYy/yP5Zodzow9Mo0zXtcBwAAAAAAAABzdGFrZTowyAiZOwAAAADIAAAAAAAAAAah2BeRN1QqmDQ3vf4qerJVf1NcinhyK2ikncAAAAAA'),
+          ),
+          <SolanaPubKey>[
+            SolanaPubKey.fromBytes(base64Decode('UZgIBV3jdeGVGJKrsLg0H3NjL/I/lmh3OjD0yjTNe1w=')),
+            SolanaPubKey.fromBytes(base64Decode('wz8cu0jrS8Gt71lzlkKPUyLwd3Wq/J2JWjpRn93SKpY=')),
+            SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqHYF5E3VCqYNDe9/ip6slV/U1yKeHIraKSdwAAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxksXFEhjMlMPUrxf1ja7gibof1E49vZigAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('3fQqBIAKVN4uWD+U8XsIlyW3ctEzNSYnEkFTJ3bS/8Y=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxk1hND+7ZuzQx0TIGvlRCgbV7hWbMU3X/QAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqHYF6UCBQtoB5Hmzm24jh5bcVD2H8Z5Ck600QAAAAA=')),
+          ],
+        );
+
+        // Assert
+        SolanaUnknownInstruction expectedSolanaUnknownInstruction =
+            const SolanaUnknownInstruction(programId: 'E9AKSDnvxFcUrvMqRVrANNZ2qdidh4AC1niGhQ6vGZxR');
+
+        expect(actualSolanaUnknownInstruction, expectedSolanaUnknownInstruction);
+      });
+
+      test('Should [return SolanaInvalidInstruction] from serialized instruction with no account keys', () {
+        // Act
+        ASolanaInstructionDecoded actualSolanaInvalidInstruction = ASolanaInstructionDecoded.decode(
+          SolanaCompiledInstruction(programIdIndex: 11, accounts: Uint8List.fromList(<int>[0, 4, 0, 23, 7, 10]), data: Uint8List.fromList(<int>[1])),
+          const <SolanaPubKey>[],
+        );
+
+        // Assert
+        SolanaInvalidInstruction expectedSolanaInvalidInstruction = const SolanaInvalidInstruction();
+
+        expect(actualSolanaInvalidInstruction, expectedSolanaInvalidInstruction);
+      });
+
+      test('Should [return SolanaInvalidInstruction] from serialized instruction with programId out of bounds', () {
+        // Act
+        ASolanaInstructionDecoded actualSolanaInvalidInstruction = ASolanaInstructionDecoded.decode(
+          SolanaCompiledInstruction(programIdIndex: 25, accounts: Uint8List.fromList(<int>[0, 4, 0, 23, 7, 10]), data: Uint8List.fromList(<int>[1])),
+          <SolanaPubKey>[
+            SolanaPubKey.fromBytes(base64Decode('HQPUAQhezlHPjfJ5rKjtbS1KlIQXuQ1NFUBUXhQYWPQ=')),
+            SolanaPubKey.fromBytes(base64Decode('rpH5txy8M7bxBPIjkHpFrfq04cryOKnpH2SiPswoAmM=')),
+            SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqHYF5E3VCqYNDe9/ip6slV/U1yKeHIraKSdwAAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAA=')),
+          ],
+        );
+
+        // Assert
+        SolanaInvalidInstruction expectedSolanaInvalidInstruction = const SolanaInvalidInstruction();
+
+        expect(actualSolanaInvalidInstruction, expectedSolanaInvalidInstruction);
+      });
+    });
+
+    group('Tests of ASolanaInstructionDecoded.decode() - _decodeSystemProgram() path', () {
+      test('Should [return SolanaSystemAccountSeedInstruction] from serialized SolanaSystemAccountSeedInstruction', () {
+        // Act
+        ASolanaInstructionDecoded actualSolanaSystemAccountSeedInstruction = SolanaSystemAccountSeedInstruction.fromSerializedData(
+          SolanaCompiledInstruction(
+              programIdIndex: 3,
+              accounts: Uint8List.fromList(<int>[0, 1]),
+              data: Uint8List.fromList(base64Decode(
+                  'AwAAAB0D1AEIXs5Rz43yeayo7W0tSpSEF7kNTRVAVF4UGFj0BwAAAAAAAABzdGFrZTo0gJ+9OwAAAADIAAAAAAAAAAah2BeRN1QqmDQ3vf4qerJVf1NcinhyK2ikncAAAAAA'))),
+          <SolanaPubKey>[
+            SolanaPubKey.fromBytes(base64Decode('HQPUAQhezlHPjfJ5rKjtbS1KlIQXuQ1NFUBUXhQYWPQ=')),
+            SolanaPubKey.fromBytes(base64Decode('aEARPNX8ZRouNCND7kdsxxGz9DM9YBdiHCKxvxt1e0Q=')),
+            SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqHYF5E3VCqYNDe9/ip6slV/U1yKeHIraKSdwAAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxksXFEhjMlMPUrxf1ja7gibof1E49vZigAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('3fQqBIAKVN4uWD+U8XsIlyW3ctEzNSYnEkFTJ3bS/8Y=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxk1hND+7ZuzQx0TIGvlRCgbV7hWbMU3X/QAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqHYF6UCBQtoB5Hmzm24jh5bcVD2H8Z5Ck600QAAAAA=')),
+          ],
+          '11111111111111111111111111111111',
+        );
+
+        // Assert
+        SolanaSystemAccountSeedInstruction expectedSolanaSystemAccountSeedInstruction = SolanaSystemAccountSeedInstruction(
+          programId: '11111111111111111111111111111111',
+          source: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+          newAccount: '81x4biFxxCL9hwJsX8PE8oz9omi3RcjLWRbt7Hw2kuwq',
+          base: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+          seed: 'stake:4',
+          lamports: BigInt.from(1002282880),
+          space: 200,
+          owner: 'Stake11111111111111111111111111111111111111',
+          discriminator: 3,
+        );
+
+        expect(actualSolanaSystemAccountSeedInstruction, expectedSolanaSystemAccountSeedInstruction);
+      });
+
+      test('Should [return SolanaSystemTransferInstruction] from serialized SolanaSystemTransferInstruction', () {
+        // Act
+        ASolanaInstructionDecoded actualSolanaSystemTransferInstruction = ASolanaInstructionDecoded.decode(
+          SolanaCompiledInstruction(
+              programIdIndex: 2, accounts: Uint8List.fromList(<int>[0, 1]), data: Uint8List.fromList(<int>[2, 0, 0, 0, 0, 202, 154, 59, 0, 0, 0, 0])),
+          <SolanaPubKey>[
+            SolanaPubKey.fromBytes(base64Decode('HQPUAQhezlHPjfJ5rKjtbS1KlIQXuQ1NFUBUXhQYWPQ=')),
+            SolanaPubKey.fromBytes(base64Decode('UZgIBV3jdeGVGJKrsLg0H3NjL/I/lmh3OjD0yjTNe1w=')),
+            SolanaPubKey.fromBytes(base64Decode('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+          ],
+        );
+
+        // Assert
+        SolanaSystemTransferInstruction expectedSolanaSystemTransferInstruction = SolanaSystemTransferInstruction(
+          programId: '11111111111111111111111111111111',
+          source: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+          destination: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+          lamports: BigInt.from(1000000000),
+          discriminator: 2,
+        );
+
+        expect(actualSolanaSystemTransferInstruction, expectedSolanaSystemTransferInstruction);
+      });
+
+      test('Should [return SolanaUnknownInstruction] from serialized system program instruction with an unknown tag', () {
+        // Act
+        ASolanaInstructionDecoded actualSolanaUnknownInstruction = ASolanaInstructionDecoded.decode(
+          SolanaCompiledInstruction(
+            programIdIndex: 3,
+            accounts: Uint8List.fromList(<int>[0, 1]),
+            data: base64Decode(
+                'AQAAAFGYCAVd43XhlRiSq7C4NB9zYy/yP5Zodzow9Mo0zXtcBwAAAAAAAABzdGFrZTowyAiZOwAAAADIAAAAAAAAAAah2BeRN1QqmDQ3vf4qerJVf1NcinhyK2ikncAAAAAA'),
+          ),
+          <SolanaPubKey>[
+            SolanaPubKey.fromBytes(base64Decode('UZgIBV3jdeGVGJKrsLg0H3NjL/I/lmh3OjD0yjTNe1w=')),
+            SolanaPubKey.fromBytes(base64Decode('wz8cu0jrS8Gt71lzlkKPUyLwd3Wq/J2JWjpRn93SKpY=')),
+            SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqHYF5E3VCqYNDe9/ip6slV/U1yKeHIraKSdwAAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxksXFEhjMlMPUrxf1ja7gibof1E49vZigAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('3fQqBIAKVN4uWD+U8XsIlyW3ctEzNSYnEkFTJ3bS/8Y=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxk1hND+7ZuzQx0TIGvlRCgbV7hWbMU3X/QAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqHYF6UCBQtoB5Hmzm24jh5bcVD2H8Z5Ck600QAAAAA=')),
+          ],
+        );
+
+        // Assert
+        SolanaUnknownInstruction expectedSolanaUnknownInstruction = const SolanaUnknownInstruction(programId: '11111111111111111111111111111111');
+
+        expect(actualSolanaUnknownInstruction, expectedSolanaUnknownInstruction);
+      });
+    });
+
+    group('Tests of ASolanaInstructionDecoded.decode() - _decodeTokenProgram() path', () {
+      test('Should [return SolanaTokenTransferInstruction] from serialized SolanaTokenTransferInstruction', () {
+        // Act
+        ASolanaInstructionDecoded actualSolanaTokenTransferInstruction = ASolanaInstructionDecoded.decode(
+          SolanaCompiledInstruction(
+              programIdIndex: 5, accounts: Uint8List.fromList(<int>[2, 3, 1, 0]), data: Uint8List.fromList(<int>[12, 64, 66, 15, 0, 0, 0, 0, 0, 6])),
+          <SolanaPubKey>[
+            SolanaPubKey.fromBytes(base64Decode('HQPUAQhezlHPjfJ5rKjtbS1KlIQXuQ1NFUBUXhQYWPQ=')),
+            SolanaPubKey.fromBytes(base64Decode('QcP4RyZsB5mqKLVXbVwJOPUQz1BEAbKAvrz2grGLjSg=')),
+            SolanaPubKey.fromBytes(base64Decode('fgTQkptSwcCd6H+RFKHWRBILwGHlUQiXdfuEeaD99kM=')),
+            SolanaPubKey.fromBytes(base64Decode('O0Qss5EhV/E6kz0BNCgtAytf/s0Botvxt3kGCN8ALqc=')),
+            SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('Bt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKk=')),
+          ],
+        );
+
+        // Assert
+        SolanaTokenTransferCheckedInstruction expectedSolanaTokenTransferInstruction = SolanaTokenTransferCheckedInstruction(
+          programId: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+          source: '9UvdRv2CoyLrgdGbobrQu6feMoapdzY1oqueuYMBfLWv',
+          destination: '5RipPdH3QLE7cyKzf7HKDrUoBrPKNi8odK866vJZV3AP',
+          amount: BigInt.from(1000000),
+          mint: '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU',
+          authority: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+          decimals: 6,
+          discriminator: 12,
+        );
+
+        expect(actualSolanaTokenTransferInstruction, expectedSolanaTokenTransferInstruction);
+      });
+
+      test('Should [return SolanaUnknownInstruction] from serialized token transfer instruction with an unknown tag', () {
+        // Act
+        ASolanaInstructionDecoded actualSolanaUnknownInstruction = ASolanaInstructionDecoded.decode(
+          SolanaCompiledInstruction(
+              programIdIndex: 5, accounts: Uint8List.fromList(<int>[2, 3, 1, 0]), data: Uint8List.fromList(<int>[11, 64, 66, 15, 0, 0, 0, 0, 0, 6])),
+          <SolanaPubKey>[
+            SolanaPubKey.fromBytes(base64Decode('HQPUAQhezlHPjfJ5rKjtbS1KlIQXuQ1NFUBUXhQYWPQ=')),
+            SolanaPubKey.fromBytes(base64Decode('QcP4RyZsB5mqKLVXbVwJOPUQz1BEAbKAvrz2grGLjSg=')),
+            SolanaPubKey.fromBytes(base64Decode('fgTQkptSwcCd6H+RFKHWRBILwGHlUQiXdfuEeaD99kM=')),
+            SolanaPubKey.fromBytes(base64Decode('O0Qss5EhV/E6kz0BNCgtAytf/s0Botvxt3kGCN8ALqc=')),
+            SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('Bt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKk=')),
+          ],
+        );
+
+        // Assert
+        SolanaUnknownInstruction expectedSolanaUnknownInstruction =
+            const SolanaUnknownInstruction(programId: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+
+        expect(actualSolanaUnknownInstruction, expectedSolanaUnknownInstruction);
+      });
+    });
+
+    group('Tests of ASolanaInstructionDecoded.decode() - _decodeComputeBudgetProgram() path', () {
+      test('Should [return SolanaComputeBudgetSetComputeUnitPriceInstruction] from serialized SolanaComputeBudgetSetComputeUnitPriceInstruction', () {
+        // Act
+        ASolanaInstructionDecoded actualSolanaComputeBudgetSetComputeUnitPriceInstruction = ASolanaInstructionDecoded.decode(
+          SolanaCompiledInstruction(programIdIndex: 3, accounts: Uint8List(0), data: Uint8List.fromList(<int>[3, 0, 45, 49, 1, 0, 0, 0, 0])),
+          <SolanaPubKey>[
+            SolanaPubKey.fromBytes(base64Decode('HQPUAQhezlHPjfJ5rKjtbS1KlIQXuQ1NFUBUXhQYWPQ=')),
+            SolanaPubKey.fromBytes(base64Decode('UZgIBV3jdeGVGJKrsLg0H3NjL/I/lmh3OjD0yjTNe1w=')),
+            SolanaPubKey.fromBytes(base64Decode('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+          ],
+        );
+
+        // Assert
+        SolanaComputeBudgetUnitPriceInstruction expectedSolanaComputeBudgetSetComputeUnitPriceInstruction =
+            const SolanaComputeBudgetUnitPriceInstruction(
+          discriminator: 3,
+          programId: 'ComputeBudget111111111111111111111111111111',
+          microLamports: 20000000,
+        );
+
+        expect(actualSolanaComputeBudgetSetComputeUnitPriceInstruction, expectedSolanaComputeBudgetSetComputeUnitPriceInstruction);
+      });
+
+      test('Should [return SolanaComputeBudgetSetComputeUnitLimitInstruction] from serialized SolanaComputeBudgetSetComputeUnitLimitInstruction', () {
+        // Act
+        ASolanaInstructionDecoded actualSolanaComputeBudgetSetComputeUnitLimitInstruction = ASolanaInstructionDecoded.decode(
+          SolanaCompiledInstruction(programIdIndex: 3, accounts: Uint8List(0), data: Uint8List.fromList(<int>[2, 239, 1, 0, 0])),
+          <SolanaPubKey>[
+            SolanaPubKey.fromBytes(base64Decode('HQPUAQhezlHPjfJ5rKjtbS1KlIQXuQ1NFUBUXhQYWPQ=')),
+            SolanaPubKey.fromBytes(base64Decode('UZgIBV3jdeGVGJKrsLg0H3NjL/I/lmh3OjD0yjTNe1w=')),
+            SolanaPubKey.fromBytes(base64Decode('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+          ],
+        );
+
+        // Assert
+        SolanaComputeBudgetUnitLimitInstruction expectedSolanaComputeBudgetSetComputeUnitLimitInstruction =
+            const SolanaComputeBudgetUnitLimitInstruction(
+          discriminator: 2,
+          programId: 'ComputeBudget111111111111111111111111111111',
+          units: 495,
+        );
+
+        expect(actualSolanaComputeBudgetSetComputeUnitLimitInstruction, expectedSolanaComputeBudgetSetComputeUnitLimitInstruction);
+      });
+
+      test('Should [return SolanaUnknownInstruction] from serialized compute budget instruction with an unknown tag', () {
+        // Act
+        ASolanaInstructionDecoded actualSolanaUnknownInstruction = ASolanaInstructionDecoded.decode(
+          SolanaCompiledInstruction(programIdIndex: 3, accounts: Uint8List(0), data: Uint8List.fromList(<int>[1, 0, 45, 49, 1, 0, 0, 0, 0])),
+          <SolanaPubKey>[
+            SolanaPubKey.fromBytes(base64Decode('HQPUAQhezlHPjfJ5rKjtbS1KlIQXuQ1NFUBUXhQYWPQ=')),
+            SolanaPubKey.fromBytes(base64Decode('UZgIBV3jdeGVGJKrsLg0H3NjL/I/lmh3OjD0yjTNe1w=')),
+            SolanaPubKey.fromBytes(base64Decode('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+          ],
+        );
+
+        // Assert
+        SolanaUnknownInstruction expectedSolanaUnknownInstruction =
+            const SolanaUnknownInstruction(programId: 'ComputeBudget111111111111111111111111111111');
+
+        expect(actualSolanaUnknownInstruction, expectedSolanaUnknownInstruction);
+      });
+    });
+
+    group('Tests of ASolanaInstructionDecoded.decode() - _decodeStakeProgram() path', () {
+      test('Should [return SolanaStakeInitializeInstruction] from serialized SolanaStakeInitializeInstruction', () {
+        // Act
+        ASolanaInstructionDecoded actualSolanaStakeInitializeInstruction = ASolanaInstructionDecoded.decode(
+          SolanaCompiledInstruction(
+            programIdIndex: 4,
+            accounts: Uint8List.fromList(<int>[1, 5]),
+            data: base64Decode(
+                'AAAAAFGYCAVd43XhlRiSq7C4NB9zYy/yP5Zodzow9Mo0zXtcUZgIBV3jdeGVGJKrsLg0H3NjL/I/lmh3OjD0yjTNe1wAAAAAAAAAAAAAAAAAAAAAUZgIBV3jdeGVGJKrsLg0H3NjL/I/lmh3OjD0yjTNe1w='),
+          ),
+          <SolanaPubKey>[
+            SolanaPubKey.fromBytes(base64Decode('UZgIBV3jdeGVGJKrsLg0H3NjL/I/lmh3OjD0yjTNe1w=')),
+            SolanaPubKey.fromBytes(base64Decode('wz8cu0jrS8Gt71lzlkKPUyLwd3Wq/J2JWjpRn93SKpY=')),
+            SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqHYF5E3VCqYNDe9/ip6slV/U1yKeHIraKSdwAAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxksXFEhjMlMPUrxf1ja7gibof1E49vZigAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('3fQqBIAKVN4uWD+U8XsIlyW3ctEzNSYnEkFTJ3bS/8Y=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxk1hND+7ZuzQx0TIGvlRCgbV7hWbMU3X/QAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqHYF6UCBQtoB5Hmzm24jh5bcVD2H8Z5Ck600QAAAAA=')),
+          ],
+        );
+
+        // Assert
+        SolanaStakeInitializeInstruction expectedSolanaStakeInitializeInstruction = const SolanaStakeInitializeInstruction(
+          custodian: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+          epoch: 0,
+          programId: 'Stake11111111111111111111111111111111111111',
+          rentSysvar: 'SysvarRent111111111111111111111111111111111',
+          stakeAccount: 'E9AKSDnvxFcUrvMqRVrANNZ2qdidh4AC1niGhQ6vGZxR',
+          staker: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+          unixTimestamp: 0,
+          withdrawer: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+          discriminator: 0,
+        );
+
+        expect(actualSolanaStakeInitializeInstruction, expectedSolanaStakeInitializeInstruction);
+      });
+
+      test('Should [return SolanaStakeDelegateInstruction] from serialized SolanaStakeDelegateInstruction', () {
+        // Act
+        ASolanaInstructionDecoded actualSolanaStakeDelegateInstruction = ASolanaInstructionDecoded.decode(
+          SolanaCompiledInstruction(
+              programIdIndex: 4, accounts: Uint8List.fromList(<int>[1, 6, 7, 8, 9, 0]), data: Uint8List.fromList(<int>[2, 0, 0, 0])),
+          <SolanaPubKey>[
+            SolanaPubKey.fromBytes(base64Decode('UZgIBV3jdeGVGJKrsLg0H3NjL/I/lmh3OjD0yjTNe1w=')),
+            SolanaPubKey.fromBytes(base64Decode('wz8cu0jrS8Gt71lzlkKPUyLwd3Wq/J2JWjpRn93SKpY=')),
+            SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqHYF5E3VCqYNDe9/ip6slV/U1yKeHIraKSdwAAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxksXFEhjMlMPUrxf1ja7gibof1E49vZigAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('3fQqBIAKVN4uWD+U8XsIlyW3ctEzNSYnEkFTJ3bS/8Y=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxk1hND+7ZuzQx0TIGvlRCgbV7hWbMU3X/QAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqHYF6UCBQtoB5Hmzm24jh5bcVD2H8Z5Ck600QAAAAA=')),
+          ],
+        );
+
+        // Assert
+        SolanaStakeDelegateInstruction expectedSolanaStakeDelegateInstruction = const SolanaStakeDelegateInstruction(
+          clockSysvar: 'SysvarC1ock11111111111111111111111111111111',
+          programId: 'Stake11111111111111111111111111111111111111',
+          stakeAuthority: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+          stakeAccount: 'E9AKSDnvxFcUrvMqRVrANNZ2qdidh4AC1niGhQ6vGZxR',
+          stakeConfigAccount: 'StakeConfig11111111111111111111111111111111',
+          stakeHistorySysvar: 'SysvarStakeHistory1111111111111111111111111',
+          voteAccount: 'FwR3PbjS5iyqzLiLugrBqKSa5EKZ4vK9SKs7eQXtT59f',
+          discriminator: 2,
+        );
+
+        expect(actualSolanaStakeDelegateInstruction, expectedSolanaStakeDelegateInstruction);
+      });
+
+      test('Should [return SolanaStakeDeactivateInstruction] from serialized SolanaStakeDeactivateInstruction', () {
+        // Act
+        ASolanaInstructionDecoded actualSolanaStakeDeactivateInstruction = ASolanaInstructionDecoded.decode(
+          SolanaCompiledInstruction(programIdIndex: 3, accounts: Uint8List.fromList(<int>[1, 4, 0]), data: Uint8List.fromList(<int>[5, 0, 0, 0])),
+          <SolanaPubKey>[
+            SolanaPubKey.fromBytes(base64Decode('HQPUAQhezlHPjfJ5rKjtbS1KlIQXuQ1NFUBUXhQYWPQ=')),
+            SolanaPubKey.fromBytes(base64Decode('rpH5txy8M7bxBPIjkHpFrfq04cryOKnpH2SiPswoAmM=')),
+            SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqHYF5E3VCqYNDe9/ip6slV/U1yKeHIraKSdwAAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAA=')),
+          ],
+        );
+
+        // Assert
+        SolanaStakeDeactivateInstruction expectedSolanaStakeDeactivateInstruction = const SolanaStakeDeactivateInstruction(
+          programId: 'Stake11111111111111111111111111111111111111',
+          clockSysvar: 'SysvarC1ock11111111111111111111111111111111',
+          stakeAccount: 'CkT3NP8HMam7v73564b638kPBvy8SGTt9mNjuLtRw79k',
+          stakeAuthority: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+          discriminator: 5,
+        );
+
+        expect(actualSolanaStakeDeactivateInstruction, expectedSolanaStakeDeactivateInstruction);
+      });
+
+      test('Should [return SolanaStakeWithdrawInstruction] from serialized SolanaStakeWithdrawInstruction', () {
+        // Act
+        ASolanaInstructionDecoded actualSolanaStakeWithdrawInstruction = ASolanaInstructionDecoded.decode(
+          SolanaCompiledInstruction(
+              programIdIndex: 3,
+              accounts: Uint8List.fromList(<int>[1, 0, 4, 5, 0]),
+              data: Uint8List.fromList(<int>[4, 0, 0, 0, 128, 159, 189, 59, 0, 0, 0, 0])),
+          <SolanaPubKey>[
+            SolanaPubKey.fromBytes(base64Decode('HQPUAQhezlHPjfJ5rKjtbS1KlIQXuQ1NFUBUXhQYWPQ=')),
+            SolanaPubKey.fromBytes(base64Decode('rpH5txy8M7bxBPIjkHpFrfq04cryOKnpH2SiPswoAmM=')),
+            SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqHYF5E3VCqYNDe9/ip6slV/U1yKeHIraKSdwAAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxk1hND+7ZuzQx0TIGvlRCgbV7hWbMU3X/QAAAA=')),
+          ],
+        );
+
+        // Assert
+        SolanaStakeWithdrawInstruction expectedSolanaStakeWithdrawInstruction = SolanaStakeWithdrawInstruction(
+          clockSysvar: 'SysvarC1ock11111111111111111111111111111111',
+          destination: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+          programId: 'Stake11111111111111111111111111111111111111',
+          lamports: BigInt.from(1002282880),
+          stakeAccount: 'CkT3NP8HMam7v73564b638kPBvy8SGTt9mNjuLtRw79k',
+          stakeHistorySysvar: 'SysvarStakeHistory1111111111111111111111111',
+          withdrawAuthority: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+          discriminator: 4,
+        );
+
+        expect(actualSolanaStakeWithdrawInstruction, expectedSolanaStakeWithdrawInstruction);
+      });
+
+      test('Should [return SolanaUnknownInstruction] from serialized stake instruction with an unknown tag', () {
+        // Act
+        ASolanaInstructionDecoded actualSolanaUnknownInstruction = ASolanaInstructionDecoded.decode(
+          SolanaCompiledInstruction(programIdIndex: 3, accounts: Uint8List.fromList(<int>[1, 4, 0]), data: Uint8List.fromList(<int>[1, 0, 0, 0])),
+          <SolanaPubKey>[
+            SolanaPubKey.fromBytes(base64Decode('HQPUAQhezlHPjfJ5rKjtbS1KlIQXuQ1NFUBUXhQYWPQ=')),
+            SolanaPubKey.fromBytes(base64Decode('rpH5txy8M7bxBPIjkHpFrfq04cryOKnpH2SiPswoAmM=')),
+            SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqHYF5E3VCqYNDe9/ip6slV/U1yKeHIraKSdwAAAAAA=')),
+            SolanaPubKey.fromBytes(base64Decode('BqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAA=')),
+          ],
+        );
+
+        // Assert
+        SolanaUnknownInstruction expectedSolanaUnknownInstruction =
+            const SolanaUnknownInstruction(programId: 'Stake11111111111111111111111111111111111111');
+
+        expect(actualSolanaUnknownInstruction, expectedSolanaUnknownInstruction);
+      });
+    });
+  });
+
+  group('Tests of ASolanaInstructionDecoded.getAmount()', () {
+    test('Should [return TokenAmount (0)] from 0 lamports', () {
+      // Arrange
+      SolanaSystemTransferInstruction actualSolanaSystemTransferInstruction = SolanaSystemTransferInstruction(
+        programId: '11111111111111111111111111111111',
+        source: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        destination: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        lamports: BigInt.from(0),
+        discriminator: 2,
+      );
+
+      // Act
+      TokenAmount? actualTokenAmount = actualSolanaSystemTransferInstruction.getAmount();
+
+      // Assert
+      TokenAmount expectedTokenAmount = TokenAmount(denomination: 'SOL', amount: Decimal.fromInt(0));
+
+      expect(actualTokenAmount, expectedTokenAmount);
+    });
+
+    test('Should [return TokenAmount] from an arbitrary amount of lamports', () {
+      // Arrange
+      SolanaSystemTransferInstruction actualSolanaSystemTransferInstruction = SolanaSystemTransferInstruction(
+        programId: '11111111111111111111111111111111',
+        source: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        destination: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        lamports: BigInt.from(100000000),
+        discriminator: 2,
+      );
+
+      // Act
+      TokenAmount? actualTokenAmount = actualSolanaSystemTransferInstruction.getAmount();
+
+      // Assert
+      TokenAmount expectedTokenAmount = TokenAmount(denomination: 'SOL', amount: Decimal.parse('0.1'));
+
+      expect(actualTokenAmount, expectedTokenAmount);
+    });
+
+    test('Should [return TokenAmount (0)] from 0 tokens', () {
+      // Arrange
+      SolanaTokenTransferCheckedInstruction actualSolanaTokenTransferCheckedInstruction = SolanaTokenTransferCheckedInstruction(
+        programId: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+        source: '9UvdRv2CoyLrgdGbobrQu6feMoapdzY1oqueuYMBfLWv',
+        destination: '5RipPdH3QLE7cyKzf7HKDrUoBrPKNi8odK866vJZV3AP',
+        amount: BigInt.from(0),
+        mint: '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU',
+        authority: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        decimals: 6,
+        discriminator: 12,
+      );
+
+      // Act
+      TokenAmount? actualTokenAmount = actualSolanaTokenTransferCheckedInstruction.getAmount();
+
+      // Assert
+      TokenAmount expectedTokenAmount = TokenAmount(denomination: '', amount: Decimal.fromInt(0));
+
+      expect(actualTokenAmount, expectedTokenAmount);
+    });
+
+    test('Should [return TokenAmount] from an arbitrary amount of tokens', () {
+      // Arrange
+      SolanaTokenTransferCheckedInstruction actualSolanaTokenTransferCheckedInstruction = SolanaTokenTransferCheckedInstruction(
+        programId: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+        source: '9UvdRv2CoyLrgdGbobrQu6feMoapdzY1oqueuYMBfLWv',
+        destination: '5RipPdH3QLE7cyKzf7HKDrUoBrPKNi8odK866vJZV3AP',
+        amount: BigInt.from(1000000),
+        mint: '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU',
+        authority: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        decimals: 6,
+        discriminator: 12,
+      );
+
+      // Act
+      TokenAmount? actualTokenAmount = actualSolanaTokenTransferCheckedInstruction.getAmount();
+
+      // Assert
+      TokenAmount expectedTokenAmount = TokenAmount(denomination: '', amount: Decimal.fromInt(1));
+
+      expect(actualTokenAmount, expectedTokenAmount);
+    });
+
+    test('Should [return null] from an instruction with undefined amount and lamports', () {
+      // Arrange
+      SolanaComputeBudgetUnitLimitInstruction actualSolanaComputeBudgetUnitSetComputeLimitInstruction = const SolanaComputeBudgetUnitLimitInstruction(
+        discriminator: 2,
+        programId: 'ComputeBudget111111111111111111111111111111',
+        units: 495,
+      );
+
+      // Act
+      TokenAmount? actualTokenAmount = actualSolanaComputeBudgetUnitSetComputeLimitInstruction.getAmount();
+
+      // Assert
+      expect(actualTokenAmount, null);
+    });
+  });
+
+  group('Tests of ASolanaInstructionDecoded.getMintAddress()', () {
+    test('Should [return mint address] from an instruction WITH mint', () {
+      // Arrange
+      SolanaTokenTransferCheckedInstruction actualASolanaInstructionDecoded = SolanaTokenTransferCheckedInstruction(
+        programId: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+        source: '9UvdRv2CoyLrgdGbobrQu6feMoapdzY1oqueuYMBfLWv',
+        destination: '5RipPdH3QLE7cyKzf7HKDrUoBrPKNi8odK866vJZV3AP',
+        amount: BigInt.from(1000000),
+        mint: '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU',
+        authority: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        decimals: 6,
+        discriminator: 12,
+      );
+
+      // Act
+      String? actualMintAddress = actualASolanaInstructionDecoded.getMintAddress();
+
+      // Assert
+      String expectedMintAddress = '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU';
+
+      expect(actualMintAddress, expectedMintAddress);
+    });
+
+    test('Should [return null] for an instruction WITHOUT mint', () {
+      // Arrange
+      ASolanaInstructionDecoded actualASolanaInstructionDecoded = const SolanaComputeBudgetUnitPriceInstruction(
+        discriminator: 3,
+        programId: 'ComputeBudget111111111111111111111111111111',
+        microLamports: 20000000,
+      );
+
+      // Act
+      String? actualMintAddress = actualASolanaInstructionDecoded.getMintAddress();
+
+      // Assert
+      String? expectedMintAddress;
+
+      expect(actualMintAddress, expectedMintAddress);
+    });
+  });
+
+  group('Tests of ASolanaInstructionDecoded.getSenderAddress()', () {
+    test('Should [return stakeAuthority as SENDER ADDRESS] from a SolanaStakeDeactivateInstruction', () {
+      // Arrange
+      ASolanaInstructionDecoded actualASolanaInstructionDecoded = const SolanaStakeDeactivateInstruction(
+        programId: 'Stake11111111111111111111111111111111111111',
+        clockSysvar: 'SysvarC1ock11111111111111111111111111111111',
+        stakeAccount: 'CkT3NP8HMam7v73564b638kPBvy8SGTt9mNjuLtRw79k',
+        stakeAuthority: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        discriminator: 5,
+      );
+
+      // Act
+      String? actualSenderAddress = actualASolanaInstructionDecoded.getSenderAddress();
+
+      // Assert
+      String expectedSenderAddress = '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19';
+
+      expect(actualSenderAddress, expectedSenderAddress);
+    });
+
+    test('Should [return stakeAuthority as SENDER ADDRESS] from a SolanaStakeDelegateInstruction', () {
+      // Arrange
+      ASolanaInstructionDecoded actualASolanaInstructionDecoded = const SolanaStakeDelegateInstruction(
+        clockSysvar: 'SysvarC1ock11111111111111111111111111111111',
+        programId: 'Stake11111111111111111111111111111111111111',
+        stakeAccount: 'E9AKSDnvxFcUrvMqRVrANNZ2qdidh4AC1niGhQ6vGZxR',
+        stakeAuthority: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        stakeConfigAccount: 'StakeConfig11111111111111111111111111111111',
+        stakeHistorySysvar: 'SysvarStakeHistory1111111111111111111111111',
+        voteAccount: 'FwR3PbjS5iyqzLiLugrBqKSa5EKZ4vK9SKs7eQXtT59f',
+        discriminator: 2,
+      );
+
+      // Act
+      String? actualSenderAddress = actualASolanaInstructionDecoded.getSenderAddress();
+
+      // Assert
+      String? expectedSenderAddress = '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z';
+
+      expect(actualSenderAddress, expectedSenderAddress);
+    });
+
+    test('Should [return STAKER as SENDER ADDRESS] from a SolanaStakeInitializeInstruction', () {
+      // Arrange
+      SolanaStakeInitializeInstruction actualASolanaInstructionDecoded = const SolanaStakeInitializeInstruction(
+        programId: 'Stake11111111111111111111111111111111111111',
+        custodian: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        epoch: 0,
+        rentSysvar: 'SysvarRent111111111111111111111111111111111',
+        stakeAccount: 'E9AKSDnvxFcUrvMqRVrANNZ2qdidh4AC1niGhQ6vGZxR',
+        staker: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        unixTimestamp: 0,
+        withdrawer: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        discriminator: 0,
+      );
+
+      // Act
+      String? actualSenderAddress = actualASolanaInstructionDecoded.getSenderAddress();
+
+      // Assert
+      String? expectedSenderAddress = '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z';
+
+      expect(actualSenderAddress, expectedSenderAddress);
+    });
+
+    test('Should [return stakeAccount as SENDER ADDRESS] from a SolanaStakeWithdrawInstruction', () {
+      // Arrange
+      SolanaStakeWithdrawInstruction actualASolanaInstructionDecoded = SolanaStakeWithdrawInstruction(
+        clockSysvar: 'SysvarC1ock11111111111111111111111111111111',
+        destination: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        programId: 'Stake11111111111111111111111111111111111111',
+        lamports: BigInt.from(1002282880),
+        stakeAccount: 'CkT3NP8HMam7v73564b638kPBvy8SGTt9mNjuLtRw79k',
+        stakeHistorySysvar: 'SysvarStakeHistory1111111111111111111111111',
+        withdrawAuthority: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        discriminator: 4,
+      );
+
+      // Act
+      String? actualSenderAddress = actualASolanaInstructionDecoded.getSenderAddress();
+
+      // Assert
+      String? expectedSenderAddress = 'CkT3NP8HMam7v73564b638kPBvy8SGTt9mNjuLtRw79k';
+
+      expect(actualSenderAddress, expectedSenderAddress);
+    });
+
+    test('Should [return source as SENDER ADDRESS] from a SolanaSystemTransferInstruction', () {
+      // Arrange
+      ASolanaInstructionDecoded actualASolanaInstructionDecoded = SolanaSystemTransferInstruction(
+        programId: '11111111111111111111111111111111',
+        source: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        destination: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        lamports: BigInt.from(1000000000),
+        discriminator: 2,
+      );
+
+      // Act
+      String? actualSenderAddress = actualASolanaInstructionDecoded.getSenderAddress();
+
+      // Assert
+      String? expectedSenderAddress = '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19';
+
+      expect(actualSenderAddress, expectedSenderAddress);
+    });
+
+    test('Should [return source as SENDER ADDRESS] from a SolanaTokenTransferCheckedInstruction', () {
+      // Arrange
+      ASolanaInstructionDecoded actualASolanaInstructionDecoded = SolanaTokenTransferCheckedInstruction(
+        programId: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+        source: '9UvdRv2CoyLrgdGbobrQu6feMoapdzY1oqueuYMBfLWv',
+        destination: '5RipPdH3QLE7cyKzf7HKDrUoBrPKNi8odK866vJZV3AP',
+        amount: BigInt.from(1000000),
+        mint: '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU',
+        authority: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        decimals: 6,
+        discriminator: 12,
+      );
+
+      // Act
+      String? actualSenderAddress = actualASolanaInstructionDecoded.getSenderAddress();
+
+      // Assert
+      String? expectedSenderAddress = '9UvdRv2CoyLrgdGbobrQu6feMoapdzY1oqueuYMBfLWv';
+
+      expect(actualSenderAddress, expectedSenderAddress);
+    });
+
+    test('Should [return NULL] for an instruction WITHOUT source, stakeAccount, stakeAuthority or staker', () {
+      // Arrange
+      ASolanaInstructionDecoded actualASolanaInstructionDecoded = const SolanaComputeBudgetUnitPriceInstruction(
+        discriminator: 3,
+        programId: 'ComputeBudget111111111111111111111111111111',
+        microLamports: 20000000,
+      );
+
+      // Act
+      String? actualSenderAddress = actualASolanaInstructionDecoded.getSenderAddress();
+
+      // Assert
+      String? expectedSenderAddress;
+
+      expect(actualSenderAddress, expectedSenderAddress);
+    });
+  });
+
+  group('Tests of ASolanaInstructionDecoded.getRecipientAddress()', () {
+    test('Should [return stakeAccount as RECIPIENT ADDRESS] from a SolanaStakeDeactivateInstruction', () {
+      // Arrange
+      ASolanaInstructionDecoded actualASolanaInstructionDecoded = const SolanaStakeDeactivateInstruction(
+        programId: 'Stake11111111111111111111111111111111111111',
+        clockSysvar: 'SysvarC1ock11111111111111111111111111111111',
+        stakeAccount: 'CkT3NP8HMam7v73564b638kPBvy8SGTt9mNjuLtRw79k',
+        stakeAuthority: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        discriminator: 5,
+      );
+
+      // Act
+      String? actualRecipientAddress = actualASolanaInstructionDecoded.getRecipientAddress();
+
+      // Assert
+      String expectedRecipientAddress = 'CkT3NP8HMam7v73564b638kPBvy8SGTt9mNjuLtRw79k';
+
+      expect(actualRecipientAddress, expectedRecipientAddress);
+    });
+
+    test('Should [return stakeAccount as RECIPIENT ADDRESS] from a SolanaStakeDelegateInstruction', () {
+      // Arrange
+      ASolanaInstructionDecoded actualASolanaInstructionDecoded = const SolanaStakeDelegateInstruction(
+        clockSysvar: 'SysvarC1ock11111111111111111111111111111111',
+        programId: 'Stake11111111111111111111111111111111111111',
+        stakeAccount: 'E9AKSDnvxFcUrvMqRVrANNZ2qdidh4AC1niGhQ6vGZxR',
+        stakeAuthority: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        stakeConfigAccount: 'StakeConfig11111111111111111111111111111111',
+        stakeHistorySysvar: 'SysvarStakeHistory1111111111111111111111111',
+        voteAccount: 'FwR3PbjS5iyqzLiLugrBqKSa5EKZ4vK9SKs7eQXtT59f',
+        discriminator: 2,
+      );
+
+      // Act
+      String? actualRecipientAddress = actualASolanaInstructionDecoded.getRecipientAddress();
+
+      // Assert
+      String? expectedRecipientAddress = 'E9AKSDnvxFcUrvMqRVrANNZ2qdidh4AC1niGhQ6vGZxR';
+
+      expect(actualRecipientAddress, expectedRecipientAddress);
+    });
+
+    test('Should [return stakeAccount as RECIPIENT ADDRESS] from a SolanaStakeInitializeInstruction', () {
+      // Arrange
+      SolanaStakeInitializeInstruction actualASolanaInstructionDecoded = const SolanaStakeInitializeInstruction(
+        programId: 'Stake11111111111111111111111111111111111111',
+        custodian: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        epoch: 0,
+        rentSysvar: 'SysvarRent111111111111111111111111111111111',
+        stakeAccount: 'E9AKSDnvxFcUrvMqRVrANNZ2qdidh4AC1niGhQ6vGZxR',
+        staker: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        unixTimestamp: 0,
+        withdrawer: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        discriminator: 0,
+      );
+
+      // Act
+      String? actualRecipientAddress = actualASolanaInstructionDecoded.getRecipientAddress();
+
+      // Assert
+      String? expectedRecipientAddress = 'E9AKSDnvxFcUrvMqRVrANNZ2qdidh4AC1niGhQ6vGZxR';
+
+      expect(actualRecipientAddress, expectedRecipientAddress);
+    });
+
+    test('Should [return destination as RECIPIENT ADDRESS] from a SolanaStakeWithdrawInstruction', () {
+      // Arrange
+      SolanaStakeWithdrawInstruction actualASolanaInstructionDecoded = SolanaStakeWithdrawInstruction(
+        clockSysvar: 'SysvarC1ock11111111111111111111111111111111',
+        destination: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        programId: 'Stake11111111111111111111111111111111111111',
+        lamports: BigInt.from(1002282880),
+        stakeAccount: 'CkT3NP8HMam7v73564b638kPBvy8SGTt9mNjuLtRw79k',
+        stakeHistorySysvar: 'SysvarStakeHistory1111111111111111111111111',
+        withdrawAuthority: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        discriminator: 4,
+      );
+
+      // Act
+      String? actualRecipientAddress = actualASolanaInstructionDecoded.getRecipientAddress();
+
+      // Assert
+      String? expectedRecipientAddress = '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19';
+
+      expect(actualRecipientAddress, expectedRecipientAddress);
+    });
+
+    test('Should [return destination as RECIPIENT ADDRESS] from a SolanaSystemAccountSeedInstruction', () {
+      // Arrange
+      SolanaSystemAccountSeedInstruction actualSolanaSystemAccountSeedInstruction = SolanaSystemAccountSeedInstruction(
+        programId: '11111111111111111111111111111111',
+        source: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        newAccount: '81x4biFxxCL9hwJsX8PE8oz9omi3RcjLWRbt7Hw2kuwq',
+        base: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        seed: 'stake:4',
+        lamports: BigInt.from(1002282880),
+        space: 200,
+        owner: 'Stake11111111111111111111111111111111111111',
+        discriminator: 3,
+      );
+
+      // Act
+      String? actualRecipientAddress = actualSolanaSystemAccountSeedInstruction.getRecipientAddress();
+
+      // Assert
+      String? expectedRecipientAddress = '81x4biFxxCL9hwJsX8PE8oz9omi3RcjLWRbt7Hw2kuwq';
+
+      expect(actualRecipientAddress, expectedRecipientAddress);
+    });
+
+    test('Should [return destination as RECIPIENT ADDRESS] from a SolanaSystemTransferInstruction', () {
+      // Arrange
+      ASolanaInstructionDecoded actualASolanaInstructionDecoded = SolanaSystemTransferInstruction(
+        programId: '11111111111111111111111111111111',
+        source: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        destination: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        lamports: BigInt.from(1000000000),
+        discriminator: 2,
+      );
+
+      // Act
+      String? actualRecipientAddress = actualASolanaInstructionDecoded.getRecipientAddress();
+
+      // Assert
+      String? expectedRecipientAddress = '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z';
+
+      expect(actualRecipientAddress, expectedRecipientAddress);
+    });
+
+    test('Should [return destination as RECIPIENT ADDRESS] from a SolanaTokenTransferCheckedInstruction', () {
+      // Arrange
+      ASolanaInstructionDecoded actualASolanaInstructionDecoded = SolanaTokenTransferCheckedInstruction(
+        programId: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+        source: '9UvdRv2CoyLrgdGbobrQu6feMoapdzY1oqueuYMBfLWv',
+        destination: '5RipPdH3QLE7cyKzf7HKDrUoBrPKNi8odK866vJZV3AP',
+        amount: BigInt.from(1000000),
+        mint: '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU',
+        authority: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        decimals: 6,
+        discriminator: 12,
+      );
+
+      // Act
+      String? actualRecipientAddress = actualASolanaInstructionDecoded.getRecipientAddress();
+
+      // Assert
+      String? expectedRecipientAddress = '5RipPdH3QLE7cyKzf7HKDrUoBrPKNi8odK866vJZV3AP';
+
+      expect(actualRecipientAddress, expectedRecipientAddress);
+    });
+
+    test('Should [return NULL] for an instruction WITHOUT destination or stakeAccount', () {
+      // Arrange
+      ASolanaInstructionDecoded actualASolanaInstructionDecoded = const SolanaComputeBudgetUnitPriceInstruction(
+        discriminator: 3,
+        programId: 'ComputeBudget111111111111111111111111111111',
+        microLamports: 20000000,
+      );
+
+      // Act
+      String? actualRecipientAddress = actualASolanaInstructionDecoded.getRecipientAddress();
+
+      // Assert
+      String? expectedRecipientAddress;
+
+      expect(actualRecipientAddress, expectedRecipientAddress);
+    });
+  });
+
+  group('Tests of ASolanaInstructionDecoded.getSignerAddress()', () {
+    test('Should [return stakeAuthority as SIGNER ADDRESS] from a SolanaStakeDeactivateInstruction', () {
+      // Arrange
+      ASolanaInstructionDecoded actualASolanaInstructionDecoded = const SolanaStakeDeactivateInstruction(
+        programId: 'Stake11111111111111111111111111111111111111',
+        clockSysvar: 'SysvarC1ock11111111111111111111111111111111',
+        stakeAccount: 'CkT3NP8HMam7v73564b638kPBvy8SGTt9mNjuLtRw79k',
+        stakeAuthority: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        discriminator: 5,
+      );
+
+      // Act
+      String? actualSenderAddress = actualASolanaInstructionDecoded.getSignerAddress();
+
+      // Assert
+      String expectedSenderAddress = '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19';
+
+      expect(actualSenderAddress, expectedSenderAddress);
+    });
+
+    test('Should [return stakeAuthority as SIGNER ADDRESS] from a SolanaStakeDelegateInstruction', () {
+      // Arrange
+      ASolanaInstructionDecoded actualASolanaInstructionDecoded = const SolanaStakeDelegateInstruction(
+        clockSysvar: 'SysvarC1ock11111111111111111111111111111111',
+        programId: 'Stake11111111111111111111111111111111111111',
+        stakeAccount: 'E9AKSDnvxFcUrvMqRVrANNZ2qdidh4AC1niGhQ6vGZxR',
+        stakeAuthority: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        stakeConfigAccount: 'StakeConfig11111111111111111111111111111111',
+        stakeHistorySysvar: 'SysvarStakeHistory1111111111111111111111111',
+        voteAccount: 'FwR3PbjS5iyqzLiLugrBqKSa5EKZ4vK9SKs7eQXtT59f',
+        discriminator: 2,
+      );
+
+      // Act
+      String? actualSenderAddress = actualASolanaInstructionDecoded.getSignerAddress();
+
+      // Assert
+      String? expectedSenderAddress = '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z';
+
+      expect(actualSenderAddress, expectedSenderAddress);
+    });
+
+    test('Should [return staker as SIGNER ADDRESS] from a SolanaStakeInitializeInstruction', () {
+      // Arrange
+      SolanaStakeInitializeInstruction actualASolanaInstructionDecoded = const SolanaStakeInitializeInstruction(
+        programId: 'Stake11111111111111111111111111111111111111',
+        custodian: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        epoch: 0,
+        rentSysvar: 'SysvarRent111111111111111111111111111111111',
+        stakeAccount: 'E9AKSDnvxFcUrvMqRVrANNZ2qdidh4AC1niGhQ6vGZxR',
+        staker: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        unixTimestamp: 0,
+        withdrawer: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        discriminator: 0,
+      );
+
+      // Act
+      String? actualSenderAddress = actualASolanaInstructionDecoded.getSignerAddress();
+
+      // Assert
+      String? expectedSenderAddress = '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z';
+
+      expect(actualSenderAddress, expectedSenderAddress);
+    });
+
+    test('Should [return withdrawAuthority as SIGNER ADDRESS] from a SolanaStakeWithdrawInstruction', () {
+      // Arrange
+      SolanaStakeWithdrawInstruction actualASolanaInstructionDecoded = SolanaStakeWithdrawInstruction(
+        clockSysvar: 'SysvarC1ock11111111111111111111111111111111',
+        destination: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        programId: 'Stake11111111111111111111111111111111111111',
+        lamports: BigInt.from(1002282880),
+        stakeAccount: 'CkT3NP8HMam7v73564b638kPBvy8SGTt9mNjuLtRw79k',
+        stakeHistorySysvar: 'SysvarStakeHistory1111111111111111111111111',
+        withdrawAuthority: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        discriminator: 4,
+      );
+
+      // Act
+      String? actualSenderAddress = actualASolanaInstructionDecoded.getSignerAddress();
+
+      // Assert
+      String? expectedSenderAddress = '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19';
+
+      expect(actualSenderAddress, expectedSenderAddress);
+    });
+
+    test('Should [return source as SIGNER ADDRESS] from a SolanaSystemTransferInstruction', () {
+      // Arrange
+      ASolanaInstructionDecoded actualASolanaInstructionDecoded = SolanaSystemTransferInstruction(
+        programId: '11111111111111111111111111111111',
+        source: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        destination: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        lamports: BigInt.from(1000000000),
+        discriminator: 2,
+      );
+
+      // Act
+      String? actualSenderAddress = actualASolanaInstructionDecoded.getSignerAddress();
+
+      // Assert
+      String? expectedSenderAddress = '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19';
+
+      expect(actualSenderAddress, expectedSenderAddress);
+    });
+
+    test('Should [return authority as SIGNER ADDRESS] from a SolanaTokenTransferCheckedInstruction', () {
+      // Arrange
+      ASolanaInstructionDecoded actualASolanaInstructionDecoded = SolanaTokenTransferCheckedInstruction(
+        programId: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+        source: '9UvdRv2CoyLrgdGbobrQu6feMoapdzY1oqueuYMBfLWv',
+        destination: '5RipPdH3QLE7cyKzf7HKDrUoBrPKNi8odK866vJZV3AP',
+        amount: BigInt.from(1000000),
+        mint: '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU',
+        authority: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        decimals: 6,
+        discriminator: 12,
+      );
+
+      // Act
+      String? actualSenderAddress = actualASolanaInstructionDecoded.getSignerAddress();
+
+      // Assert
+      String? expectedSenderAddress = '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19';
+
+      expect(actualSenderAddress, expectedSenderAddress);
+    });
+
+    test('Should [return NULL] for an instruction WITHOUT authority, stakeAuthority, withdrawAuthority, staker or source', () {
+      // Arrange
+      ASolanaInstructionDecoded actualASolanaInstructionDecoded = const SolanaComputeBudgetUnitPriceInstruction(
+        discriminator: 3,
+        programId: 'ComputeBudget111111111111111111111111111111',
+        microLamports: 20000000,
+      );
+
+      // Act
+      String? actualSenderAddress = actualASolanaInstructionDecoded.getSignerAddress();
+
+      // Assert
+      String? expectedSenderAddress;
+
+      expect(actualSenderAddress, expectedSenderAddress);
+    });
+  });
+}

--- a/test/transactions/solana/instructions/compute_budget/solana_compute_budget_set_compute_unit_limit_instruction_test.dart
+++ b/test/transactions/solana/instructions/compute_budget/solana_compute_budget_set_compute_unit_limit_instruction_test.dart
@@ -1,0 +1,26 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SolanaComputeBudgetUnitLimitInstruction.fromSerializedData()', () {
+    test('Should [return SolanaComputeBudgetUnitLimitInstruction] from serialized data', () {
+      // Act
+      SolanaComputeBudgetUnitLimitInstruction actualSolanaComputeBudgetUnitLimitInstruction =
+          SolanaComputeBudgetUnitLimitInstruction.fromSerializedData(
+        SolanaCompiledInstruction(programIdIndex: 3, accounts: Uint8List(0), data: Uint8List.fromList(<int>[2, 239, 1, 0, 0])),
+        'ComputeBudget111111111111111111111111111111',
+      );
+
+      // Assert
+      SolanaComputeBudgetUnitLimitInstruction expectedSolanaComputeBudgetUnitLimitInstruction = const SolanaComputeBudgetUnitLimitInstruction(
+        discriminator: 2,
+        programId: 'ComputeBudget111111111111111111111111111111',
+        units: 495,
+      );
+
+      expect(actualSolanaComputeBudgetUnitLimitInstruction, expectedSolanaComputeBudgetUnitLimitInstruction);
+    });
+  });
+}

--- a/test/transactions/solana/instructions/compute_budget/solana_compute_budget_set_compute_unit_price_instruction_test.dart
+++ b/test/transactions/solana/instructions/compute_budget/solana_compute_budget_set_compute_unit_price_instruction_test.dart
@@ -1,0 +1,26 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SolanaComputeBudgetUnitPriceInstruction.fromSerializedData()', () {
+    test('Should [return SolanaComputeBudgetUnitPriceInstruction] from serialized data', () {
+      // Act
+      SolanaComputeBudgetUnitPriceInstruction actualSolanaComputeBudgetUnitPriceInstruction =
+          SolanaComputeBudgetUnitPriceInstruction.fromSerializedData(
+        SolanaCompiledInstruction(programIdIndex: 3, accounts: Uint8List(0), data: Uint8List.fromList(<int>[3, 0, 45, 49, 1, 0, 0, 0, 0])),
+        'ComputeBudget111111111111111111111111111111',
+      );
+
+      // Assert
+      SolanaComputeBudgetUnitPriceInstruction expectedSolanaComputeBudgetUnitPriceInstruction = const SolanaComputeBudgetUnitPriceInstruction(
+        discriminator: 3,
+        programId: 'ComputeBudget111111111111111111111111111111',
+        microLamports: 20000000,
+      );
+
+      expect(actualSolanaComputeBudgetUnitPriceInstruction, expectedSolanaComputeBudgetUnitPriceInstruction);
+    });
+  });
+}

--- a/test/transactions/solana/instructions/solana_compiled_instruction_test.dart
+++ b/test/transactions/solana/instructions/solana_compiled_instruction_test.dart
@@ -1,0 +1,33 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SolanaCompiledInstruction.fromSerializedData()', () {
+    test('Should [return SolanaCompiledInstruction] from serialized data', () {
+      // Act
+      SolanaCompiledInstruction actualSolanaCompiledInstruction =
+          SolanaCompiledInstruction.fromSerializedData(ByteReader(Uint8List.fromList(<int>[1, 2, 3, 4, 3, 100, 101, 102])));
+
+      // Assert
+      SolanaCompiledInstruction expectedSolanaCompiledInstruction =
+          SolanaCompiledInstruction(programIdIndex: 1, accounts: Uint8List.fromList(<int>[3, 4]), data: Uint8List.fromList(<int>[100, 101, 102]));
+
+      expect(actualSolanaCompiledInstruction, expectedSolanaCompiledInstruction);
+    });
+
+    test('Should [return SolanaCompiledInstruction] with zero-length accounts and data', () {
+      // Act
+      SolanaCompiledInstruction actualSolanaCompiledInstruction =
+          SolanaCompiledInstruction.fromSerializedData(ByteReader(Uint8List.fromList(<int>[1, 0, 0])));
+
+      // Assert
+      SolanaCompiledInstruction expectedSolanaCompiledInstruction =
+          SolanaCompiledInstruction(programIdIndex: 1, accounts: Uint8List(0), data: Uint8List(0));
+
+      expect(actualSolanaCompiledInstruction, expectedSolanaCompiledInstruction);
+    });
+  });
+}

--- a/test/transactions/solana/instructions/stake_program/solana_stake_deactivate_instruction_test.dart
+++ b/test/transactions/solana/instructions/stake_program/solana_stake_deactivate_instruction_test.dart
@@ -1,0 +1,35 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SolanaStakeDeactivateInstruction.fromSerializedData()', () {
+    test('Should [return fromSerializedData] from serialized data', () {
+      // Act
+      SolanaStakeDeactivateInstruction actualSolanaStakeDeactivateInstruction = SolanaStakeDeactivateInstruction.fromSerializedData(
+        SolanaCompiledInstruction(programIdIndex: 3, accounts: Uint8List.fromList(<int>[1, 4, 0]), data: Uint8List.fromList(<int>[5, 0, 0, 0])),
+        <SolanaPubKey>[
+          SolanaPubKey.fromBytes(base64Decode('HQPUAQhezlHPjfJ5rKjtbS1KlIQXuQ1NFUBUXhQYWPQ=')),
+          SolanaPubKey.fromBytes(base64Decode('rpH5txy8M7bxBPIjkHpFrfq04cryOKnpH2SiPswoAmM=')),
+          SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('BqHYF5E3VCqYNDe9/ip6slV/U1yKeHIraKSdwAAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('BqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAA=')),
+        ],
+        'Stake11111111111111111111111111111111111111',
+      );
+
+      // Assert
+      SolanaStakeDeactivateInstruction expectedSolanaStakeDeactivateInstruction = const SolanaStakeDeactivateInstruction(
+        programId: 'Stake11111111111111111111111111111111111111',
+        clockSysvar: 'SysvarC1ock11111111111111111111111111111111',
+        stakeAccount: 'CkT3NP8HMam7v73564b638kPBvy8SGTt9mNjuLtRw79k',
+        stakeAuthority: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        discriminator: 5,
+      );
+
+      expect(actualSolanaStakeDeactivateInstruction, expectedSolanaStakeDeactivateInstruction);
+    });
+  });
+}

--- a/test/transactions/solana/instructions/stake_program/solana_stake_delegate_instruction_test.dart
+++ b/test/transactions/solana/instructions/stake_program/solana_stake_delegate_instruction_test.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SolanaStakeDelegateInstruction.fromSerializedData()', () {
+    test('Should [return SolanaStakeDelegateInstruction] from serialized data', () {
+      // Act
+      SolanaStakeDelegateInstruction actualSolanaStakeDelegateInstruction = SolanaStakeDelegateInstruction.fromSerializedData(
+        SolanaCompiledInstruction(
+            programIdIndex: 4, accounts: Uint8List.fromList(<int>[1, 6, 7, 8, 9, 0]), data: Uint8List.fromList(<int>[2, 0, 0, 0])),
+        <SolanaPubKey>[
+          SolanaPubKey.fromBytes(base64Decode('UZgIBV3jdeGVGJKrsLg0H3NjL/I/lmh3OjD0yjTNe1w=')),
+          SolanaPubKey.fromBytes(base64Decode('wz8cu0jrS8Gt71lzlkKPUyLwd3Wq/J2JWjpRn93SKpY=')),
+          SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('BqHYF5E3VCqYNDe9/ip6slV/U1yKeHIraKSdwAAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('BqfVFxksXFEhjMlMPUrxf1ja7gibof1E49vZigAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('3fQqBIAKVN4uWD+U8XsIlyW3ctEzNSYnEkFTJ3bS/8Y=')),
+          SolanaPubKey.fromBytes(base64Decode('BqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('BqfVFxk1hND+7ZuzQx0TIGvlRCgbV7hWbMU3X/QAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('BqHYF6UCBQtoB5Hmzm24jh5bcVD2H8Z5Ck600QAAAAA=')),
+        ],
+        'Stake11111111111111111111111111111111111111',
+      );
+
+      // Assert
+      SolanaStakeDelegateInstruction expectedSolanaStakeDelegateInstruction = const SolanaStakeDelegateInstruction(
+        clockSysvar: 'SysvarC1ock11111111111111111111111111111111',
+        programId: 'Stake11111111111111111111111111111111111111',
+        stakeAccount: 'E9AKSDnvxFcUrvMqRVrANNZ2qdidh4AC1niGhQ6vGZxR',
+        stakeAuthority: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        stakeConfigAccount: 'StakeConfig11111111111111111111111111111111',
+        stakeHistorySysvar: 'SysvarStakeHistory1111111111111111111111111',
+        voteAccount: 'FwR3PbjS5iyqzLiLugrBqKSa5EKZ4vK9SKs7eQXtT59f',
+        discriminator: 2,
+      );
+
+      expect(actualSolanaStakeDelegateInstruction, expectedSolanaStakeDelegateInstruction);
+    });
+  });
+}

--- a/test/transactions/solana/instructions/stake_program/solana_stake_initialize_instruction_test.dart
+++ b/test/transactions/solana/instructions/stake_program/solana_stake_initialize_instruction_test.dart
@@ -1,0 +1,48 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SolanaStakeInitializeInstruction.fromSerializedData()', () {
+    test('Should [return SolanaStakeInitializeInstruction] from serialized data', () {
+      // Act
+      SolanaStakeInitializeInstruction actualSolanaStakeInitializeInstruction = SolanaStakeInitializeInstruction.fromSerializedData(
+        SolanaCompiledInstruction(
+            programIdIndex: 4,
+            accounts: Uint8List.fromList(<int>[1, 5]),
+            data: base64Decode(
+                'AAAAAFGYCAVd43XhlRiSq7C4NB9zYy/yP5Zodzow9Mo0zXtcUZgIBV3jdeGVGJKrsLg0H3NjL/I/lmh3OjD0yjTNe1wAAAAAAAAAAAAAAAAAAAAAUZgIBV3jdeGVGJKrsLg0H3NjL/I/lmh3OjD0yjTNe1w=')),
+        <SolanaPubKey>[
+          SolanaPubKey.fromBytes(base64Decode('UZgIBV3jdeGVGJKrsLg0H3NjL/I/lmh3OjD0yjTNe1w=')),
+          SolanaPubKey.fromBytes(base64Decode('wz8cu0jrS8Gt71lzlkKPUyLwd3Wq/J2JWjpRn93SKpY=')),
+          SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('BqHYF5E3VCqYNDe9/ip6slV/U1yKeHIraKSdwAAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('BqfVFxksXFEhjMlMPUrxf1ja7gibof1E49vZigAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('3fQqBIAKVN4uWD+U8XsIlyW3ctEzNSYnEkFTJ3bS/8Y=')),
+          SolanaPubKey.fromBytes(base64Decode('BqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('BqfVFxk1hND+7ZuzQx0TIGvlRCgbV7hWbMU3X/QAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('BqHYF6UCBQtoB5Hmzm24jh5bcVD2H8Z5Ck600QAAAAA=')),
+        ],
+        'Stake11111111111111111111111111111111111111',
+      );
+
+      // Assert
+      SolanaStakeInitializeInstruction expectedSolanaStakeInitializeInstruction = const SolanaStakeInitializeInstruction(
+        programId: 'Stake11111111111111111111111111111111111111',
+        custodian: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        epoch: 0,
+        rentSysvar: 'SysvarRent111111111111111111111111111111111',
+        stakeAccount: 'E9AKSDnvxFcUrvMqRVrANNZ2qdidh4AC1niGhQ6vGZxR',
+        staker: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        unixTimestamp: 0,
+        withdrawer: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        discriminator: 0,
+      );
+
+      expect(actualSolanaStakeInitializeInstruction, expectedSolanaStakeInitializeInstruction);
+    });
+  });
+}

--- a/test/transactions/solana/instructions/stake_program/solana_stake_withdraw_instruction_test.dart
+++ b/test/transactions/solana/instructions/stake_program/solana_stake_withdraw_instruction_test.dart
@@ -1,0 +1,42 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SolanaStakeWithdrawInstruction.fromSerializedData()', () {
+    test('Should [return SolanaStakeWithdrawInstruction] from serialized data', () {
+      // Act
+      SolanaStakeWithdrawInstruction actualSolanaStakeWithdrawInstruction = SolanaStakeWithdrawInstruction.fromSerializedData(
+        SolanaCompiledInstruction(
+            programIdIndex: 3,
+            accounts: Uint8List.fromList(<int>[1, 0, 4, 5, 0]),
+            data: Uint8List.fromList(<int>[4, 0, 0, 0, 128, 159, 189, 59, 0, 0, 0, 0])),
+        <SolanaPubKey>[
+          SolanaPubKey.fromBytes(base64Decode('HQPUAQhezlHPjfJ5rKjtbS1KlIQXuQ1NFUBUXhQYWPQ=')),
+          SolanaPubKey.fromBytes(base64Decode('rpH5txy8M7bxBPIjkHpFrfq04cryOKnpH2SiPswoAmM=')),
+          SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('BqHYF5E3VCqYNDe9/ip6slV/U1yKeHIraKSdwAAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('BqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('BqfVFxk1hND+7ZuzQx0TIGvlRCgbV7hWbMU3X/QAAAA=')),
+        ],
+        'Stake11111111111111111111111111111111111111',
+      );
+
+      // Assert
+      SolanaStakeWithdrawInstruction expectedSolanaStakeWithdrawInstruction = SolanaStakeWithdrawInstruction(
+        clockSysvar: 'SysvarC1ock11111111111111111111111111111111',
+        destination: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        programId: 'Stake11111111111111111111111111111111111111',
+        lamports: BigInt.from(1002282880),
+        stakeAccount: 'CkT3NP8HMam7v73564b638kPBvy8SGTt9mNjuLtRw79k',
+        stakeHistorySysvar: 'SysvarStakeHistory1111111111111111111111111',
+        withdrawAuthority: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        discriminator: 4,
+      );
+
+      expect(actualSolanaStakeWithdrawInstruction, expectedSolanaStakeWithdrawInstruction);
+    });
+  });
+}

--- a/test/transactions/solana/instructions/system_program/solana_system_account_seed_instruction_test.dart
+++ b/test/transactions/solana/instructions/system_program/solana_system_account_seed_instruction_test.dart
@@ -1,0 +1,77 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:decimal/decimal.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SolanaSystemAccountSeedInstruction.fromSerializedData()', () {
+    test('Should [return SolanaSystemAccountSeedInstruction] from serialized data', () {
+      // Act
+      SolanaSystemAccountSeedInstruction actualSolanaSystemAccountSeedInstruction = SolanaSystemAccountSeedInstruction.fromSerializedData(
+        SolanaCompiledInstruction(
+            programIdIndex: 3,
+            accounts: Uint8List.fromList(<int>[0, 1]),
+            data: Uint8List.fromList(base64Decode(
+                'AwAAAB0D1AEIXs5Rz43yeayo7W0tSpSEF7kNTRVAVF4UGFj0BwAAAAAAAABzdGFrZTo0gJ+9OwAAAADIAAAAAAAAAAah2BeRN1QqmDQ3vf4qerJVf1NcinhyK2ikncAAAAAA'))),
+        <SolanaPubKey>[
+          SolanaPubKey.fromBytes(base64Decode('HQPUAQhezlHPjfJ5rKjtbS1KlIQXuQ1NFUBUXhQYWPQ=')),
+          SolanaPubKey.fromBytes(base64Decode('aEARPNX8ZRouNCND7kdsxxGz9DM9YBdiHCKxvxt1e0Q=')),
+          SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('BqHYF5E3VCqYNDe9/ip6slV/U1yKeHIraKSdwAAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('BqfVFxksXFEhjMlMPUrxf1ja7gibof1E49vZigAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('3fQqBIAKVN4uWD+U8XsIlyW3ctEzNSYnEkFTJ3bS/8Y=')),
+          SolanaPubKey.fromBytes(base64Decode('BqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('BqfVFxk1hND+7ZuzQx0TIGvlRCgbV7hWbMU3X/QAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('BqHYF6UCBQtoB5Hmzm24jh5bcVD2H8Z5Ck600QAAAAA=')),
+        ],
+        '11111111111111111111111111111111',
+      );
+
+      // Assert
+      SolanaSystemAccountSeedInstruction expectedSolanaSystemAccountSeedInstruction = SolanaSystemAccountSeedInstruction(
+        programId: '11111111111111111111111111111111',
+        source: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        newAccount: '81x4biFxxCL9hwJsX8PE8oz9omi3RcjLWRbt7Hw2kuwq',
+        base: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        seed: 'stake:4',
+        lamports: BigInt.from(1002282880),
+        space: 200,
+        owner: 'Stake11111111111111111111111111111111111111',
+        discriminator: 3,
+      );
+
+      expect(actualSolanaSystemAccountSeedInstruction, expectedSolanaSystemAccountSeedInstruction);
+    });
+  });
+
+  group('Tests of SolanaSystemAccountSeedInstruction.getAmount()', () {
+    test('Should [return amount] from given SolanaSystemAccountSeedInstruction', () {
+      // Arrange
+      SolanaSystemAccountSeedInstruction actualSolanaSystemAccountSeedInstruction = SolanaSystemAccountSeedInstruction(
+        programId: '11111111111111111111111111111111',
+        source: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        newAccount: '81x4biFxxCL9hwJsX8PE8oz9omi3RcjLWRbt7Hw2kuwq',
+        base: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        seed: 'stake:4',
+        lamports: BigInt.from(1002282880),
+        space: 200,
+        owner: 'Stake11111111111111111111111111111111111111',
+        discriminator: 3,
+      );
+
+      // Act
+      TokenAmount? actualTokenAmount = actualSolanaSystemAccountSeedInstruction.getAmount();
+
+      // Assert
+      TokenAmount expectedTokenAmount = TokenAmount(
+        amount: Decimal.parse('1.00228288'),
+        denomination: 'SOL',
+      );
+
+      expect(actualTokenAmount, expectedTokenAmount);
+    });
+  });
+}

--- a/test/transactions/solana/instructions/system_program/solana_system_transfer_instruction_test.dart
+++ b/test/transactions/solana/instructions/system_program/solana_system_transfer_instruction_test.dart
@@ -1,0 +1,60 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:decimal/decimal.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SolanaSystemTransferInstruction.fromSerializedData()', () {
+    test('Should [return SolanaSystemTransferInstruction] from serialized data', () {
+      // Act
+      SolanaSystemTransferInstruction actualSolanaSystemTransferInstruction = SolanaSystemTransferInstruction.fromSerializedData(
+        SolanaCompiledInstruction(
+            programIdIndex: 2, accounts: Uint8List.fromList(<int>[0, 1]), data: Uint8List.fromList(<int>[2, 0, 0, 0, 0, 202, 154, 59, 0, 0, 0, 0])),
+        <SolanaPubKey>[
+          SolanaPubKey.fromBytes(base64Decode('HQPUAQhezlHPjfJ5rKjtbS1KlIQXuQ1NFUBUXhQYWPQ=')),
+          SolanaPubKey.fromBytes(base64Decode('UZgIBV3jdeGVGJKrsLg0H3NjL/I/lmh3OjD0yjTNe1w=')),
+          SolanaPubKey.fromBytes(base64Decode('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+        ],
+        '11111111111111111111111111111111',
+      );
+
+      // Assert
+      SolanaSystemTransferInstruction expectedSolanaSystemTransferInstruction = SolanaSystemTransferInstruction(
+        programId: '11111111111111111111111111111111',
+        source: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        destination: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        lamports: BigInt.from(1000000000),
+        discriminator: 2,
+      );
+
+      expect(actualSolanaSystemTransferInstruction, expectedSolanaSystemTransferInstruction);
+    });
+  });
+
+  group('Tests of SolanaSystemTransferInstruction.getAmount()', () {
+    test('Should [return amount] from given SolanaSystemTransferInstruction', () {
+      // Arrange
+      SolanaSystemTransferInstruction actualSolanaSystemTransferInstruction = SolanaSystemTransferInstruction(
+        programId: '11111111111111111111111111111111',
+        source: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        destination: '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z',
+        lamports: BigInt.from(100000000),
+        discriminator: 2,
+      );
+
+      // Act
+      TokenAmount? actualTokenAmount = actualSolanaSystemTransferInstruction.getAmount();
+
+      // Assert
+      TokenAmount expectedTokenAmount = TokenAmount(
+        amount: Decimal.parse('0.1'),
+        denomination: 'SOL',
+      );
+
+      expect(actualTokenAmount, expectedTokenAmount);
+    });
+  });
+}

--- a/test/transactions/solana/instructions/token_program/solana_token_transfer_checked_instruction_test.dart
+++ b/test/transactions/solana/instructions/token_program/solana_token_transfer_checked_instruction_test.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SolanaTokenTransferCheckedInstruction.fromSerializedData()', () {
+    test('Should [return SolanaTokenTransferCheckedInstruction] from serialized data', () {
+      // Act
+      SolanaTokenTransferCheckedInstruction actualSolanaTokenTransferCheckedInstruction = SolanaTokenTransferCheckedInstruction.fromSerializedData(
+        SolanaCompiledInstruction(
+            programIdIndex: 5, accounts: Uint8List.fromList(<int>[2, 3, 1, 0]), data: Uint8List.fromList(<int>[12, 64, 66, 15, 0, 0, 0, 0, 0, 6])),
+        <SolanaPubKey>[
+          SolanaPubKey.fromBytes(base64Decode('HQPUAQhezlHPjfJ5rKjtbS1KlIQXuQ1NFUBUXhQYWPQ=')),
+          SolanaPubKey.fromBytes(base64Decode('QcP4RyZsB5mqKLVXbVwJOPUQz1BEAbKAvrz2grGLjSg=')),
+          SolanaPubKey.fromBytes(base64Decode('fgTQkptSwcCd6H+RFKHWRBILwGHlUQiXdfuEeaD99kM=')),
+          SolanaPubKey.fromBytes(base64Decode('O0Qss5EhV/E6kz0BNCgtAytf/s0Botvxt3kGCN8ALqc=')),
+          SolanaPubKey.fromBytes(base64Decode('AwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAA=')),
+          SolanaPubKey.fromBytes(base64Decode('Bt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKk=')),
+        ],
+        'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+      );
+
+      // Assert
+      SolanaTokenTransferCheckedInstruction expectedSolanaTokenTransferCheckedInstruction = SolanaTokenTransferCheckedInstruction(
+        programId: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+        source: '9UvdRv2CoyLrgdGbobrQu6feMoapdzY1oqueuYMBfLWv',
+        destination: '5RipPdH3QLE7cyKzf7HKDrUoBrPKNi8odK866vJZV3AP',
+        amount: BigInt.from(1000000),
+        mint: '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU',
+        authority: '2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19',
+        decimals: 6,
+        discriminator: 12,
+      );
+
+      expect(actualSolanaTokenTransferCheckedInstruction, expectedSolanaTokenTransferCheckedInstruction);
+    });
+  });
+}

--- a/test/transactions/solana/instructions/unknown_instructions/solana_unknown_instruction_test.dart
+++ b/test/transactions/solana/instructions/unknown_instructions/solana_unknown_instruction_test.dart
@@ -1,0 +1,18 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SolanaUnknownInstruction.fromSerializedData()', () {
+    test('Should [return SolanaUnknownInstruction] from serialized data', () {
+      // Act
+      SolanaUnknownInstruction actualSolanaUnknownInstruction =
+          SolanaUnknownInstruction.fromSerializedData('SomeProgram1111111111111111111111111111111');
+
+      // Assert
+      SolanaUnknownInstruction expectedSolanaUnknownInstruction =
+          const SolanaUnknownInstruction(programId: 'SomeProgram1111111111111111111111111111111');
+
+      expect(actualSolanaUnknownInstruction, expectedSolanaUnknownInstruction);
+    });
+  });
+}

--- a/test/transactions/solana/solana_address_lookup_table_test.dart
+++ b/test/transactions/solana/solana_address_lookup_table_test.dart
@@ -1,0 +1,39 @@
+// ignore_for_file: cascade_invocations
+import 'dart:convert';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/src/transactions/solana/solana_address_lookup_table.dart';
+import 'package:cryptography_utils/src/transactions/solana/solana_pubkey.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SolanaAddressLookupTable.fromSerializedData()', () {
+    test('Should [return SolanaAddressLookupTable] from serialized data', () {
+      // Act
+      SolanaAddressLookupTable actualSolanaAddressLookupTable = SolanaAddressLookupTable.fromSerializedData(
+          ByteReader(base64Decode('wVdRxcH4wwx5hrqgGgkua/Gonv4pzAZz/LU35B3ySlkEd3Z4eQQGenVTFvHsWcITjSSy666/XikzqLiO11a0SwY8rT5d3C+q84sDvr+7AA==')));
+
+      // Assert
+      SolanaAddressLookupTable expectedSolanaAddressLookupTable = SolanaAddressLookupTable(
+          accountKey: SolanaPubKey.fromBytes(base64Decode('wVdRxcH4wwx5hrqgGgkua/Gonv4pzAZz/LU35B3ySlk=')),
+          writableIndexesList: const <int>[119, 118, 120, 121],
+          readonlyIndexesList: const <int>[6, 122, 117, 83]);
+
+      expect(actualSolanaAddressLookupTable, expectedSolanaAddressLookupTable);
+    });
+
+    test('Should [return SolanaAddressLookupTable] from serialized data with zero-length index lists', () {
+      // Act
+      SolanaAddressLookupTable actualSolanaAddressLookupTable = SolanaAddressLookupTable.fromSerializedData(
+          ByteReader(base64Decode('wVdRxcH4wwx5hrqgGgkua/Gonv4pzAZz/LU35B3ySlkAABbx7FnCE40ksuuuv14pM6i4jtdWtEsGPK0+XdwvqvOLA76/uwA=')));
+
+      // Assert
+      SolanaAddressLookupTable expectedSolanaAddressLookupTable = SolanaAddressLookupTable(
+          accountKey: SolanaPubKey.fromBytes(base64Decode('wVdRxcH4wwx5hrqgGgkua/Gonv4pzAZz/LU35B3ySlk=')),
+          writableIndexesList: const <int>[],
+          readonlyIndexesList: const <int>[]);
+
+      expect(actualSolanaAddressLookupTable, expectedSolanaAddressLookupTable);
+    });
+  });
+}

--- a/test/transactions/solana/solana_legacy_message_test.dart
+++ b/test/transactions/solana/solana_legacy_message_test.dart
@@ -1,0 +1,36 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SolanaLegacyMessage.fromSerializedData()', () {
+    test('Should [return SolanaLegacyMessage] from serialized data', () {
+      // Act
+      SolanaLegacyMessage actualSolanaLegacyMessage = SolanaLegacyMessage.fromSerializedData(Base58Codec.decode(
+          '8XvVPnpTLZqLmFm1xXHBushdVTcZDpbgbTXtmAATXbzBDyBpaoMcvxWRRwjpBpHdeJSEC5FJUB8xDAn5eZWGetF96KzQv7cdVXP1e3H2dpkgpTaNsgJD8JLgowf8LEsjBya3oog6S3hwa7VgSDAvJHXVrGPRbCxoxt2ELwT1ZANor9BnZLz2PGhpF8SDWHZkSxyEkPWxMiCpqJGYD5WqB5hS8Br5dk2HcHpRvYxxPuzfoHygJECu4JyZLgnd39qQwk9nS8UuBiAg9wXS6B1'));
+
+      // Assert
+      SolanaLegacyMessage expectedSolanaLegacyMessage = SolanaLegacyMessage(
+          header: const SolanaMessageHeader(numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 2),
+          accountKeysList: <SolanaPubKey>[
+            SolanaPubKey.fromBase58('2xGD7cWtwpmCpW2NvT9EJt96eDavS3suVgQNVaBU4A19'),
+            SolanaPubKey.fromBase58('6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z'),
+            SolanaPubKey.fromBase58('11111111111111111111111111111111'),
+            SolanaPubKey.fromBase58('ComputeBudget111111111111111111111111111111')
+          ],
+          recentBlockhash: Base58Codec.decode('DqdWewkZSAEPeC8sY4SFApoiMbYy6ScMP7JSVhyViNEV'),
+          compiledInstructions: <SolanaCompiledInstruction>[
+            SolanaCompiledInstruction(programIdIndex: 3, accounts: Uint8List(0), data: Uint8List.fromList(<int>[3, 0, 45, 49, 1, 0, 0, 0, 0])),
+            SolanaCompiledInstruction(programIdIndex: 3, accounts: Uint8List(0), data: Uint8List.fromList(<int>[2, 239, 1, 0, 0])),
+            SolanaCompiledInstruction(
+                programIdIndex: 2,
+                accounts: Uint8List.fromList(<int>[0, 1]),
+                data: Uint8List.fromList(<int>[2, 0, 0, 0, 0, 202, 154, 59, 0, 0, 0, 0])),
+          ]);
+
+      expect(actualSolanaLegacyMessage, expectedSolanaLegacyMessage);
+    });
+  });
+}

--- a/test/transactions/solana/solana_message_header_test.dart
+++ b/test/transactions/solana/solana_message_header_test.dart
@@ -1,0 +1,22 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/src/transactions/export.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SolanaMessageHeader.fromBytes()', () {
+    test('Should [return SolanaMessageHeader] from bytes', () {
+      // Act
+      SolanaMessageHeader actualSolanaMessageHeader = SolanaMessageHeader.fromBytes(ByteReader(Uint8List.fromList(<int>[1, 0, 9])));
+
+      // Assert
+      SolanaMessageHeader expectedSolanaMessageHeader = const SolanaMessageHeader(
+        numRequiredSignatures: 1,
+        numReadonlySignedAccounts: 0,
+        numReadonlyUnsignedAccounts: 9,
+      );
+      expect(actualSolanaMessageHeader, expectedSolanaMessageHeader);
+    });
+  });
+}

--- a/test/transactions/solana/solana_pubkey_test.dart
+++ b/test/transactions/solana/solana_pubkey_test.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/src/transactions/export.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SolanaPubKey.fromBytes()', () {
+    test('Should [return SolanaPubKey] from bytes', () {
+      // Act
+      SolanaPubKey actualSolanaPubKey = SolanaPubKey.fromBytes(base64Decode('FvHsWcITjSSy666/XikzqLiO11a0SwY8rT5d3C+q84s='));
+
+      // Assert
+      SolanaPubKey expectedSolanaPubKey = SolanaPubKey(base64Decode('FvHsWcITjSSy666/XikzqLiO11a0SwY8rT5d3C+q84s='));
+
+      expect(actualSolanaPubKey, expectedSolanaPubKey);
+    });
+
+    test('Should [throw Exception] when bytes length is not 32', () {
+      // Arrange
+      Uint8List actualSolanaPubKeyBytes = base64Decode('FvHsWcITjSSy666/XikzqLiO11a0SwY8rT5d3C+q8w==');
+
+      // Assert
+      expect(() => SolanaPubKey.fromBytes(actualSolanaPubKeyBytes), throwsA(isA<Exception>()));
+    });
+  });
+
+  group('Tests of SolanaPubKey.fromBase58()', () {
+    test('Should [return SolanaPubKey] from base58 string', () {
+      // Act
+      SolanaPubKey actualSolanaPubKey = SolanaPubKey.fromBase58('2YZvo6LkePK8V2G2ZaS8UxBYX2Ph6udCu5iuaYAqVM38');
+
+      // Assert
+      SolanaPubKey expectedSolanaPubKey = SolanaPubKey(base64Decode('FvHsWcITjSSy666/XikzqLiO11a0SwY8rT5d3C+q84s='));
+
+      expect(actualSolanaPubKey, expectedSolanaPubKey);
+    });
+  });
+}

--- a/test/transactions/solana/solana_raw_message_test.dart
+++ b/test/transactions/solana/solana_raw_message_test.dart
@@ -1,0 +1,73 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/src/transactions/solana/solana_raw_message.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SolanaRawMessage.fromSerializedData() constructor', () {
+    test('Should [return SolanaRawMessage] from given bytes', () {
+      // Arrange
+      Uint8List actualBytes = base64Decode(
+        'b3BlbnNlYS5pbyB3YW50cyB5b3UgdG8gc2lnbiBpbiB3aXRoIHlvdXIgYWNjb3VudDoKNlZXVXRRaUViU1h5NnZpWGt4czd4eXdldlFKWHJ1VkQxTm1oWDRha2RDMVoKCkNsaWNrIHRvIHNpZ24gaW4gYW5kIGFjY2VwdCB0aGUgT3BlblNlYSBUZXJtcyBvZiBTZXJ2aWNlIChodHRwczovL29wZW5zZWEuaW8vdG9zKSBhbmQgUHJpdmFjeSBQb2xpY3kgKGh0dHBzOi8vb3BlbnNlYS5pby9wcml2YWN5KS4KClVSSTogaHR0cHM6Ly9vcGVuc2VhLmlvLwpWZXJzaW9uOiAxCkNoYWluIElEOiAxCk5vbmNlOiBncThjcDI4aW5uODlyZ3ZhaG91c2QycXMzMwpJc3N1ZWQgQXQ6IDIwMjUtMDgtMjVUMTY6MjU6MzkuMzI5Wg==',
+      );
+
+      // Act
+      SolanaRawMessage actualSolanaRawMessage = SolanaRawMessage.fromSerializedData(actualBytes);
+
+      // Assert
+      Uint8List expectedBytes = base64Decode(
+        'b3BlbnNlYS5pbyB3YW50cyB5b3UgdG8gc2lnbiBpbiB3aXRoIHlvdXIgYWNjb3VudDoKNlZXVXRRaUViU1h5NnZpWGt4czd4eXdldlFKWHJ1VkQxTm1oWDRha2RDMVoKCkNsaWNrIHRvIHNpZ24gaW4gYW5kIGFjY2VwdCB0aGUgT3BlblNlYSBUZXJtcyBvZiBTZXJ2aWNlIChodHRwczovL29wZW5zZWEuaW8vdG9zKSBhbmQgUHJpdmFjeSBQb2xpY3kgKGh0dHBzOi8vb3BlbnNlYS5pby9wcml2YWN5KS4KClVSSTogaHR0cHM6Ly9vcGVuc2VhLmlvLwpWZXJzaW9uOiAxCkNoYWluIElEOiAxCk5vbmNlOiBncThjcDI4aW5uODlyZ3ZhaG91c2QycXMzMwpJc3N1ZWQgQXQ6IDIwMjUtMDgtMjVUMTY6MjU6MzkuMzI5Wg==',
+      );
+
+      expect(actualSolanaRawMessage.data, expectedBytes);
+    });
+  });
+
+  group('Tests of SolanaRawMessage.serialize()', () {
+    test('Should [return bytes] representing serialized transaction', () {
+      // Arrange
+      Uint8List actualBytes = base64Decode(
+        'b3BlbnNlYS5pbyB3YW50cyB5b3UgdG8gc2lnbiBpbiB3aXRoIHlvdXIgYWNjb3VudDoKNlZXVXRRaUViU1h5NnZpWGt4czd4eXdldlFKWHJ1VkQxTm1oWDRha2RDMVoKCkNsaWNrIHRvIHNpZ24gaW4gYW5kIGFjY2VwdCB0aGUgT3BlblNlYSBUZXJtcyBvZiBTZXJ2aWNlIChodHRwczovL29wZW5zZWEuaW8vdG9zKSBhbmQgUHJpdmFjeSBQb2xpY3kgKGh0dHBzOi8vb3BlbnNlYS5pby9wcml2YWN5KS4KClVSSTogaHR0cHM6Ly9vcGVuc2VhLmlvLwpWZXJzaW9uOiAxCkNoYWluIElEOiAxCk5vbmNlOiBncThjcDI4aW5uODlyZ3ZhaG91c2QycXMzMwpJc3N1ZWQgQXQ6IDIwMjUtMDgtMjVUMTY6MjU6MzkuMzI5Wg==',
+      );
+      SolanaRawMessage actualSolanaRawMessage = SolanaRawMessage.fromSerializedData(actualBytes);
+
+      // Act
+      Uint8List actualSerializedData = actualSolanaRawMessage.serialize();
+
+      // Assert
+      Uint8List expectedSerializedData = base64Decode(
+        'b3BlbnNlYS5pbyB3YW50cyB5b3UgdG8gc2lnbiBpbiB3aXRoIHlvdXIgYWNjb3VudDoKNlZXVXRRaUViU1h5NnZpWGt4czd4eXdldlFKWHJ1VkQxTm1oWDRha2RDMVoKCkNsaWNrIHRvIHNpZ24gaW4gYW5kIGFjY2VwdCB0aGUgT3BlblNlYSBUZXJtcyBvZiBTZXJ2aWNlIChodHRwczovL29wZW5zZWEuaW8vdG9zKSBhbmQgUHJpdmFjeSBQb2xpY3kgKGh0dHBzOi8vb3BlbnNlYS5pby9wcml2YWN5KS4KClVSSTogaHR0cHM6Ly9vcGVuc2VhLmlvLwpWZXJzaW9uOiAxCkNoYWluIElEOiAxCk5vbmNlOiBncThjcDI4aW5uODlyZ3ZhaG91c2QycXMzMwpJc3N1ZWQgQXQ6IDIwMjUtMDgtMjVUMTY6MjU6MzkuMzI5Wg==',
+      );
+
+      expect(actualSerializedData, expectedSerializedData);
+    });
+  });
+
+  group('Tests of SolanaRawMessage.message getter', () {
+    test('Should [return message] decoded from ASCII bytes', () {
+      // Arrange
+      Uint8List actualBytes = base64Decode(
+        'b3BlbnNlYS5pbyB3YW50cyB5b3UgdG8gc2lnbiBpbiB3aXRoIHlvdXIgYWNjb3VudDoKNlZXVXRRaUViU1h5NnZpWGt4czd4eXdldlFKWHJ1VkQxTm1oWDRha2RDMVoKCkNsaWNrIHRvIHNpZ24gaW4gYW5kIGFjY2VwdCB0aGUgT3BlblNlYSBUZXJtcyBvZiBTZXJ2aWNlIChodHRwczovL29wZW5zZWEuaW8vdG9zKSBhbmQgUHJpdmFjeSBQb2xpY3kgKGh0dHBzOi8vb3BlbnNlYS5pby9wcml2YWN5KS4KClVSSTogaHR0cHM6Ly9vcGVuc2VhLmlvLwpWZXJzaW9uOiAxCkNoYWluIElEOiAxCk5vbmNlOiBncThjcDI4aW5uODlyZ3ZhaG91c2QycXMzMwpJc3N1ZWQgQXQ6IDIwMjUtMDgtMjVUMTY6MjU6MzkuMzI5Wg==',
+      );
+      SolanaRawMessage actualSolanaRawMessage = SolanaRawMessage.fromSerializedData(actualBytes);
+
+      // Act
+      String actualMessage = actualSolanaRawMessage.message;
+
+      // Assert
+      String expectedMessage = 'opensea.io wants you to sign in with your account:\n'
+          '6VWUtQiEbSXy6viXkxs7xywevQJXruVD1NmhX4akdC1Z\n'
+          '\n'
+          'Click to sign in and accept the OpenSea Terms of Service (https://opensea.io/tos) and Privacy Policy (https://opensea.io/privacy).\n'
+          '\n'
+          'URI: https://opensea.io/\n'
+          'Version: 1\n'
+          'Chain ID: 1\n'
+          'Nonce: gq8cp28inn89rgvahousd2qs33\n'
+          'Issued At: 2025-08-25T16:25:39.329Z';
+
+      expect(actualMessage, expectedMessage);
+    });
+  });
+}

--- a/test/transactions/solana/solana_v0_message_test.dart
+++ b/test/transactions/solana/solana_v0_message_test.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:cryptography_utils/src/transactions/solana/solana_address_lookup_table.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SolanaV0Message.fromSerializedData()', () {
+    test('Should [return SolanaV0Message] from serialized data', () {
+      // Act
+      SolanaV0Message actualSolanaV0Message = SolanaV0Message.fromSerializedData(base64Decode(
+          'gAEACRCsVML2Bg3dHy0Va9dcV1Z/NhGHyVYhJ0jE+0MRGFemVlZ3NFh19IgWu+pj5UeQzMrHbNYffxTTr/qv3cxI4kqkZn/LU4VSNrEZJg9hJjEvfwMjmNLCvJDpEyG0zH7Y1yRxM32R3yvnX/HBzojB9fApPOfuRWL27j4EX6B/qtMR3YqLvMXqaJtR7xJ7zz/wsSOSpUxQmyAwTUxIhtPBZFuDzN/gj1H6SStJcojxfyVSBM4CsNHf9s8Fuywijv3R7Szf79GhSuUqLOYVkL1+ideK6TTiYEoL0lh29rNcfXJYfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAAEedVb8jHAbu50xW7OaBUH/bGy3qP0jlECsc2iVrwTjwbd9uHXZaGT2cvhRs7reawctIXtX1s3kTqM9YV+/wCpUmHRSqzFvA7sY12ocFofcKOe41qazwv48izGzkkBnXqMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WZqAC/9MhzaIlsIPwUBz6/HLWqN1/oH+Tb3IK6Tft154tD/6J/XX9kp0wJsfKVh53ksJqzbfyd1RSzIap7OM5ejnStls42Wf0xNRAChL93gEW4UQqPNOSYySLu5vwwX4aYsnkR0YRptLIlfQajrMt0F6AtCnIcxppx3jdg3dGvKxBwgABQLGggMACAAJA1IqNQAAAAAADAYABAAXBwoBAQcCAAQMAgAAAM8ntAgAAAAACgEEAREJJwoNAAQDAgUXGgYJDgkZEg8LEBEDARMTGA0KGRUPCxYUAgETExMNCirBIJszQdacgQICAAAAOgFkAAE6AGQBAs8ntAgAAAAACKmKAQAAAAAyAFAKAwQAAAEJAsFXUcXB+MMMeYa6oBoJLmvxqJ7+KcwGc/y1N+Qd8kpZBHd2eHkEBnp1Uxbx7FnCE40ksuuuv14pM6i4jtdWtEsGPK0+XdwvqvOLA76/uwA='));
+
+      // Assert
+      SolanaV0Message expectedSolanaV0Message = SolanaV0Message(
+          header: const SolanaMessageHeader(numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 9),
+          accountKeysList: <SolanaPubKey>[
+            SolanaPubKey.fromBase58('Cbi65bkTUnJWG8uesnCHg2gAEj4ujeD1SamJPe78fdq7'),
+            SolanaPubKey.fromBase58('6pXVFSACE5BND2C3ibGRWMG1fNtV7hfynWrfNKtCXhN3'),
+            SolanaPubKey.fromBase58('7u7cD7NxcZEuzRCBaYo8uVpotRdqZwez47vvuwzCov43'),
+            SolanaPubKey.fromBase58('8ctcHN52LY21FEipCjr1MVWtoZa1irJQTPyAaTj72h7S'),
+            SolanaPubKey.fromBase58('AKpr7UPK7JdQ1BjqkNmo1HQUMwve8EW6EZQhZRbiHPPY'),
+            SolanaPubKey.fromBase58('EnkAmi1xfv2rFnuU26uKn1jnAaKrg2CET3L6oF6r4Nh1'),
+            SolanaPubKey.fromBase58('G5A1npyNuMZ69GNjLTidScK42z3UZNJsmDprHfnrhCcM'),
+            SolanaPubKey.fromBase58('11111111111111111111111111111111'),
+            SolanaPubKey.fromBase58('ComputeBudget111111111111111111111111111111'),
+            SolanaPubKey.fromBase58('JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4'),
+            SolanaPubKey.fromBase58('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+            SolanaPubKey.fromBase58('6YawcNeZ74tRyCv4UfGydYMr7eho7vbUR6ScVffxKAb3'),
+            SolanaPubKey.fromBase58('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'),
+            SolanaPubKey.fromBase58('BQ72nSv9f3PRyRKCBnHLVrerrv37CYTHm5h3s9VSGQDV'),
+            SolanaPubKey.fromBase58('D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf'),
+            SolanaPubKey.fromBase58('GZsNmWKbqhMYtdSkkvMdEyQF9k5mLmP7tTKYWZjcHVPE')
+          ],
+          recentBlockhash: Base58Codec.decode('ANCfTi42idFEoiqwvagoqehUzArgbq3N6obb3Lgvhmfv'),
+          compiledInstructions: <SolanaCompiledInstruction>[
+            SolanaCompiledInstruction(programIdIndex: 8, accounts: Uint8List(0), data: Uint8List.fromList(<int>[2, 198, 130, 3, 0])),
+            SolanaCompiledInstruction(programIdIndex: 8, accounts: Uint8List(0), data: Uint8List.fromList(<int>[3, 82, 42, 53, 0, 0, 0, 0, 0])),
+            SolanaCompiledInstruction(
+                programIdIndex: 12, accounts: Uint8List.fromList(<int>[0, 4, 0, 23, 7, 10]), data: Uint8List.fromList(<int>[1])),
+            SolanaCompiledInstruction(
+                programIdIndex: 7,
+                accounts: Uint8List.fromList(<int>[0, 4]),
+                data: Uint8List.fromList(<int>[2, 0, 0, 0, 207, 39, 180, 8, 0, 0, 0, 0])),
+            SolanaCompiledInstruction(programIdIndex: 10, accounts: Uint8List.fromList(<int>[4]), data: Uint8List.fromList(<int>[17])),
+            SolanaCompiledInstruction(
+                programIdIndex: 9,
+                accounts: base64Decode('Cg0ABAMCBRcaBgkOCRkSDwsQEQMBExMYDQoZFQ8LFhQCARMTEw0K'),
+                data: base64Decode('wSCbM0HWnIECAgAAADoBZAABOgBkAQLPJ7QIAAAAAAipigEAAAAAMgBQ')),
+            SolanaCompiledInstruction(programIdIndex: 10, accounts: Uint8List.fromList(<int>[4, 0, 0]), data: Uint8List.fromList(<int>[9])),
+          ],
+          addressLookupTableList: <SolanaAddressLookupTable>[
+            SolanaAddressLookupTable(
+                accountKey: SolanaPubKey.fromBytes(base64Decode('wVdRxcH4wwx5hrqgGgkua/Gonv4pzAZz/LU35B3ySlk=')),
+                writableIndexesList: const <int>[119, 118, 120, 121],
+                readonlyIndexesList: const <int>[6, 122, 117, 83]),
+            SolanaAddressLookupTable(
+                accountKey: SolanaPubKey.fromBytes(base64Decode('FvHsWcITjSSy666/XikzqLiO11a0SwY8rT5d3C+q84s=')),
+                readonlyIndexesList: const <int>[],
+                writableIndexesList: const <int>[190, 191, 187])
+          ]);
+
+      expect(actualSolanaV0Message, expectedSolanaV0Message);
+    });
+  });
+}

--- a/test/utils/solana_utils_test.dart
+++ b/test/utils/solana_utils_test.dart
@@ -1,0 +1,48 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:cryptography_utils/src/utils/solana_utils.dart';
+import 'package:decimal/decimal.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SolanaUtils.parseTokenAmount()', () {
+    test('Should [shift amount] by given precision number (amount = 0, precision = 9)', () {
+      // Act
+      Decimal actualSOLAmount = SolanaUtils.parseTokenAmount(BigInt.zero, ASolanaInstructionDecoded.solDecimalPrecision);
+
+      // Assert
+      Decimal expectedSOLAmount = Decimal.zero;
+
+      expect(actualSOLAmount, expectedSOLAmount);
+    });
+
+    test('Should [shift amount] by given precision number (amount = 12345, precision = 4)', () {
+      // Act
+      Decimal actualTokenAmount = SolanaUtils.parseTokenAmount(BigInt.from(12345), 4);
+
+      // Assert
+      Decimal expectedTokenAmount = Decimal.parse('1.2345');
+
+      expect(actualTokenAmount, expectedTokenAmount);
+    });
+
+    test('Should [shift amount] by given precision number (amount = 1234567890, precision = 6)', () {
+      // Act
+      Decimal actualTokenAmount = SolanaUtils.parseTokenAmount(BigInt.parse('1234567890'), 6);
+
+      // Assert
+      Decimal expectedTokenAmount = Decimal.parse('1234.567890');
+
+      expect(actualTokenAmount, expectedTokenAmount);
+    });
+
+    test('Should [shift amount] by given precision number (amount = 1000000000, precision = 9)', () {
+      // Act
+      Decimal actualSOLAmount = SolanaUtils.parseTokenAmount(BigInt.from(1000000000), ASolanaInstructionDecoded.solDecimalPrecision);
+
+      // Assert
+      Decimal expectedSOLAmount = Decimal.fromInt(1);
+
+      expect(actualSOLAmount, expectedSOLAmount);
+    });
+  });
+}


### PR DESCRIPTION
This branch introduces signing Solana transactions and adds support for decoding basic Solana instructions.

List of changes:
- created solana_signer.dart - for creating Solana-compatible digital signature using an EDDSA private key
- created solana_signature.dart - a class storing digital signature used in Solana transactions
- created a_solana_message.dart - a generic wrapper for all Solana messages
- created a_solana_transaction_message.dart - a wrapper for Solana transaction messages
- created solana_compiled_instruction.dart - responsible for reading compiled instructions within a solana transaction message and storing their data
- created solana_legacy_message.dart and solana_v0_message.dart - adding support for both legacy and versioned Solana transaction message types
- created solana_raw_message.dart - adding support for Solana raw message
- created solana_message_header.dart - dedicated to extracting the very first part of the solana message
- created solana_address_lookup_table.dart - dedicated to extracting address lookup tables in v0 transactions
- created solana_pubkey.dart - representing an account's public key
- created a_solana_instruction_decoded.dart - an abstract class representing decoded Solana instructions, with a wrapper for decoding all supported Solana instructions
- created solana_program_type.dart - an enum associating solana program id with specific types of instructions
- created classes dedicated to decoding and storing specific decoded instructions ("transactions/solana/instructions")
- created solana_utils.dart - containing a method to convert token amount into a more user-friendly form